### PR TITLE
feat(abilities): register shop-domain abilities (#4)

### DIFF
--- a/extrachill-shop.php
+++ b/extrachill-shop.php
@@ -92,6 +92,9 @@ class ExtraChillShop {
 
 	// Templates
 	require_once EXTRACHILL_SHOP_PLUGIN_DIR . 'inc/templates/cart-icon.php';
+
+		// Abilities
+		require_once EXTRACHILL_SHOP_PLUGIN_DIR . 'inc/abilities/register.php';
 	}
 
 	public function load_textdomain() {

--- a/inc/abilities/register.php
+++ b/inc/abilities/register.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+/**
+ * Abilities Registration
+ *
+ * Registers the extrachill-shop ability category and loads all ability files.
+ * Each file registers its own abilities on the wp_abilities_api_init hook.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_categories_init', 'extrachill_shop_register_ability_category' );
+
+/**
+ * Register shop ability category.
+ */
+function extrachill_shop_register_ability_category(): void {
+	wp_register_ability_category(
+		'extrachill-shop',
+		array(
+			'label'       => __( 'Extra Chill Shop', 'extrachill-shop' ),
+			'description' => __( 'Shop operations: orders, products, shipping, Stripe Connect, and taxonomy counts.', 'extrachill-shop' ),
+		)
+	);
+}
+
+// Load ability files — each self-registers on wp_abilities_api_init.
+require_once __DIR__ . '/shop-list-orders.php';
+require_once __DIR__ . '/shop-refund-order.php';
+require_once __DIR__ . '/shop-update-order-status.php';
+require_once __DIR__ . '/shop-list-products.php';
+require_once __DIR__ . '/shop-get-product.php';
+require_once __DIR__ . '/shop-upload-product-image.php';
+require_once __DIR__ . '/shop-get-shipping-address.php';
+require_once __DIR__ . '/shop-update-shipping-address.php';
+require_once __DIR__ . '/shop-list-shipping-labels.php';
+require_once __DIR__ . '/shop-get-shipping-label.php';
+require_once __DIR__ . '/shop-stripe-dashboard-link.php';
+require_once __DIR__ . '/shop-stripe-onboarding-link.php';
+require_once __DIR__ . '/shop-stripe-status.php';
+require_once __DIR__ . '/shop-taxonomy-counts.php';

--- a/inc/abilities/shop-get-product.php
+++ b/inc/abilities/shop-get-product.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-get-product
+ *
+ * Get a single product by ID.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_get_product_ability' );
+
+/**
+ * Register the shop-get-product ability.
+ */
+function extrachill_shop_register_get_product_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-get-product',
+		array(
+			'label'       => __( 'Get Shop Product', 'extrachill-shop' ),
+			'description' => __( 'Get a single product by ID with full details.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id' => array(
+						'type'        => 'integer',
+						'description' => 'Product ID.',
+					),
+				),
+				'required' => array( 'id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'          => array( 'type' => 'integer' ),
+					'name'        => array( 'type' => 'string' ),
+					'description' => array( 'type' => 'string' ),
+					'price'       => array( 'type' => 'string' ),
+					'status'      => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_get_product',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				if ( current_user_can( 'manage_options' ) ) {
+					return true;
+				}
+				$product_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+				$product_post = get_post( $product_id );
+				if ( ! $product_post || 'product' !== $product_post->post_type ) {
+					return new WP_Error( 'product_not_found', 'Product not found.', array( 'status' => 404 ) );
+				}
+				$artist_id = (int) get_post_meta( $product_id, '_artist_profile_id', true );
+				if ( ! $artist_id ) {
+					return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this product.', array( 'status' => 403 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this product.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return false;
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Get a single product.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_get_product( array $input ): array|WP_Error {
+	$product_id = (int) ( $input['id'] ?? 0 );
+
+	if ( ! function_exists( 'extrachill_shop_ability_build_product_response' ) ) {
+		return new WP_Error( 'dependency_missing', 'Product helper is not loaded.', array( 'status' => 500 ) );
+	}
+
+	return extrachill_shop_ability_build_product_response( $product_id );
+}

--- a/inc/abilities/shop-get-shipping-address.php
+++ b/inc/abilities/shop-get-shipping-address.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-get-shipping-address
+ *
+ * Retrieve an artist's shipping from-address.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_get_shipping_address_ability' );
+
+/**
+ * Register the shop-get-shipping-address ability.
+ */
+function extrachill_shop_register_get_shipping_address_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-get-shipping-address',
+		array(
+			'label'       => __( 'Get Shipping Address', 'extrachill-shop' ),
+			'description' => __( 'Retrieve an artist\'s shipping from-address.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'artist_id' => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID.',
+					),
+				),
+				'required' => array( 'artist_id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'artist_id' => array( 'type' => 'integer' ),
+					'address'   => array( 'type' => 'object' ),
+					'is_set'    => array( 'type' => 'boolean' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_get_shipping_address',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				$artist_id = isset( $input['artist_id'] ) ? (int) $input['artist_id'] : 0;
+				if ( ! $artist_id ) {
+					return new WP_Error( 'missing_artist_id', 'Artist ID is required.', array( 'status' => 400 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this artist.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return current_user_can( 'manage_options' );
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Get artist shipping address.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_get_shipping_address( array $input ): array|WP_Error {
+	$artist_id = (int) ( $input['artist_id'] ?? 0 );
+
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		return new WP_Error( 'configuration_error', 'Multisite plugin is not active.', array( 'status' => 500 ) );
+	}
+
+	$artist_blog_id = ec_get_blog_id( 'artist' );
+	if ( ! $artist_blog_id ) {
+		return new WP_Error( 'configuration_error', 'Artist blog is not configured.', array( 'status' => 500 ) );
+	}
+
+	$default = array(
+		'name'    => '',
+		'street1' => '',
+		'street2' => '',
+		'city'    => '',
+		'state'   => '',
+		'zip'     => '',
+		'country' => 'US',
+	);
+
+	switch_to_blog( $artist_blog_id );
+	try {
+		$address = get_post_meta( $artist_id, '_shipping_address', true );
+		if ( ! is_array( $address ) ) {
+			$address = $default;
+		} else {
+			$address = wp_parse_args( $address, $default );
+		}
+	} finally {
+		restore_current_blog();
+	}
+
+	return array(
+		'artist_id' => $artist_id,
+		'address'   => $address,
+		'is_set'    => ! empty( $address['name'] ) && ! empty( $address['street1'] ),
+	);
+}

--- a/inc/abilities/shop-get-shipping-label.php
+++ b/inc/abilities/shop-get-shipping-label.php
@@ -1,0 +1,123 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-get-shipping-label
+ *
+ * Retrieve an existing shipping label for a specific order and artist.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_get_shipping_label_ability' );
+
+/**
+ * Register the shop-get-shipping-label ability.
+ */
+function extrachill_shop_register_get_shipping_label_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-get-shipping-label',
+		array(
+			'label'       => __( 'Get Shipping Label', 'extrachill-shop' ),
+			'description' => __( 'Retrieve an existing shipping label for a specific order.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'order_id'  => array(
+						'type'        => 'integer',
+						'description' => 'Order ID.',
+					),
+					'artist_id' => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID.',
+					),
+				),
+				'required' => array( 'order_id', 'artist_id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'order_id'        => array( 'type' => 'integer' ),
+					'artist_id'       => array( 'type' => 'integer' ),
+					'has_label'       => array( 'type' => 'boolean' ),
+					'label_url'       => array( 'type' => 'string' ),
+					'tracking_number' => array( 'type' => 'string' ),
+					'carrier'         => array( 'type' => 'string' ),
+					'service'         => array( 'type' => 'string' ),
+					'cost'            => array( 'type' => 'number' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_get_shipping_label',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				$artist_id = isset( $input['artist_id'] ) ? (int) $input['artist_id'] : 0;
+				if ( ! $artist_id ) {
+					return new WP_Error( 'missing_artist_id', 'Artist ID is required.', array( 'status' => 400 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this artist.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return current_user_can( 'manage_options' );
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Get shipping label for a specific order and artist.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_get_shipping_label( array $input ): array|WP_Error {
+	$order_id  = (int) ( $input['order_id'] ?? 0 );
+	$artist_id = (int) ( $input['artist_id'] ?? 0 );
+
+	if ( ! function_exists( 'wc_get_order' ) ) {
+		return new WP_Error( 'woocommerce_missing', 'WooCommerce is not available.', array( 'status' => 500 ) );
+	}
+
+	$order = wc_get_order( $order_id );
+	if ( ! $order ) {
+		return new WP_Error( 'order_not_found', 'Order not found.', array( 'status' => 404 ) );
+	}
+
+	$label_url       = $order->get_meta( '_artist_label_' . $artist_id ) ?: '';
+	$tracking_number = $order->get_meta( '_artist_tracking_' . $artist_id ) ?: '';
+	$label_data      = $order->get_meta( '_artist_label_data_' . $artist_id ) ?: array();
+
+	return array(
+		'order_id'        => $order_id,
+		'artist_id'       => $artist_id,
+		'has_label'       => ! empty( $label_url ),
+		'label_url'       => $label_url,
+		'tracking_number' => $tracking_number,
+		'carrier'         => $label_data['carrier'] ?? '',
+		'service'         => $label_data['service'] ?? '',
+		'cost'            => $label_data['cost'] ?? 0,
+	);
+}

--- a/inc/abilities/shop-list-orders.php
+++ b/inc/abilities/shop-list-orders.php
@@ -1,0 +1,248 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-list-orders
+ *
+ * List orders containing products from a specific artist.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_list_orders_ability' );
+
+/**
+ * Register the shop-list-orders ability.
+ */
+function extrachill_shop_register_list_orders_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-list-orders',
+		array(
+			'label'       => __( 'List Shop Orders', 'extrachill-shop' ),
+			'description' => __( 'List orders containing products from a specific artist, with filtering and pagination.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'artist_id' => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID.',
+					),
+					'status'    => array(
+						'type'        => 'string',
+						'enum'        => array( 'all', 'needs_fulfillment', 'completed' ),
+						'default'     => 'all',
+						'description' => 'Filter by fulfilment status.',
+					),
+					'page'      => array(
+						'type'        => 'integer',
+						'default'     => 1,
+						'description' => 'Page number.',
+					),
+					'per_page'  => array(
+						'type'        => 'integer',
+						'default'     => 20,
+						'description' => 'Items per page.',
+					),
+				),
+				'required' => array( 'artist_id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'orders'                  => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'object' ),
+					),
+					'total'                   => array( 'type' => 'integer' ),
+					'total_pages'             => array( 'type' => 'integer' ),
+					'page'                    => array( 'type' => 'integer' ),
+					'per_page'                => array( 'type' => 'integer' ),
+					'needs_fulfillment_count' => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_list_orders',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				$artist_id = isset( $input['artist_id'] ) ? (int) $input['artist_id'] : 0;
+				if ( ! $artist_id ) {
+					return new WP_Error( 'missing_artist_id', 'Artist ID is required.', array( 'status' => 400 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to view orders for this artist.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return current_user_can( 'manage_options' );
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * List orders for an artist.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_list_orders( array $input ): array|WP_Error {
+	$artist_id = (int) ( $input['artist_id'] ?? 0 );
+	$status    = (string) ( $input['status'] ?? 'all' );
+	$page      = max( 1, (int) ( $input['page'] ?? 1 ) );
+	$per_page  = min( 100, max( 1, (int) ( $input['per_page'] ?? 20 ) ) );
+
+	if ( ! function_exists( 'wc_get_orders' ) ) {
+		return new WP_Error( 'woocommerce_missing', 'WooCommerce is not available.', array( 'status' => 500 ) );
+	}
+
+	$wc_statuses = array( 'wc-processing', 'wc-completed', 'wc-refunded', 'wc-on-hold' );
+
+	$orders = wc_get_orders( array(
+		'limit'      => -1,
+		'status'     => $wc_statuses,
+		'orderby'    => 'date',
+		'order'      => 'DESC',
+		'meta_query' => array(
+			array(
+				'key'     => '_artist_payouts',
+				'compare' => 'EXISTS',
+			),
+		),
+	) );
+
+	$filtered_orders         = array();
+	$needs_fulfillment_count = 0;
+
+	foreach ( $orders as $order ) {
+		$payouts = $order->get_meta( '_artist_payouts' ) ?: array();
+		if ( ! isset( $payouts[ $artist_id ] ) ) {
+			continue;
+		}
+
+		$order_status = $order->get_status();
+
+		if ( 'processing' === $order_status || 'on-hold' === $order_status ) {
+			$needs_fulfillment_count++;
+		}
+
+		if ( 'needs_fulfillment' === $status && ! in_array( $order_status, array( 'processing', 'on-hold' ), true ) ) {
+			continue;
+		}
+
+		if ( 'completed' === $status && 'completed' !== $order_status && 'refunded' !== $order_status ) {
+			continue;
+		}
+
+		$filtered_orders[] = $order;
+	}
+
+	$total        = count( $filtered_orders );
+	$total_pages  = (int) ceil( $total / $per_page );
+	$offset       = ( $page - 1 ) * $per_page;
+	$paged_orders = array_slice( $filtered_orders, $offset, $per_page );
+
+	$response_orders = array();
+	foreach ( $paged_orders as $order ) {
+		$response_orders[] = extrachill_shop_ability_build_order_response( $order, $artist_id );
+	}
+
+	return array(
+		'orders'                  => $response_orders,
+		'total'                   => $total,
+		'total_pages'             => $total_pages,
+		'page'                    => $page,
+		'per_page'                => $per_page,
+		'needs_fulfillment_count' => $needs_fulfillment_count,
+	);
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build order response for an artist.
+ *
+ * @param WC_Order $order     WooCommerce order.
+ * @param int      $artist_id Artist profile ID.
+ * @return array
+ */
+function extrachill_shop_ability_build_order_response( $order, int $artist_id ): array {
+	$payouts         = $order->get_meta( '_artist_payouts' ) ?: array();
+	$artist_payout   = $payouts[ $artist_id ] ?? array();
+	$tracking_number = $order->get_meta( '_artist_tracking_' . $artist_id ) ?: '';
+
+	$items = array();
+	if ( ! empty( $artist_payout['items'] ) ) {
+		foreach ( $artist_payout['items'] as $item_data ) {
+			$product_id = $item_data['product_id'] ?? 0;
+			$product    = function_exists( 'wc_get_product' ) ? wc_get_product( $product_id ) : null;
+
+			$items[] = array(
+				'product_id' => $product_id,
+				'name'       => $product ? $product->get_name() : 'Unknown Product',
+				'quantity'   => $item_data['quantity'] ?? 1,
+				'total'      => (float) ( $item_data['line_total'] ?? 0 ),
+			);
+		}
+	}
+
+	$shipping = $order->get_address( 'shipping' );
+	$billing  = $order->get_address( 'billing' );
+	$address  = ! empty( $shipping['address_1'] ) ? $shipping : $billing;
+
+	$ships_free_only = false;
+	if ( ! empty( $artist_payout['items'] ) && is_array( $artist_payout['items'] ) ) {
+		$ships_free_only = true;
+		foreach ( $artist_payout['items'] as $item_data ) {
+			$pid = $item_data['product_id'] ?? 0;
+			if ( $pid && '1' !== get_post_meta( $pid, '_ships_free', true ) ) {
+				$ships_free_only = false;
+				break;
+			}
+		}
+	}
+
+	return array(
+		'id'              => $order->get_id(),
+		'number'          => $order->get_order_number(),
+		'status'          => $order->get_status(),
+		'date_created'    => $order->get_date_created() ? $order->get_date_created()->format( 'c' ) : '',
+		'customer'        => array(
+			'name'    => trim( $order->get_billing_first_name() . ' ' . $order->get_billing_last_name() ),
+			'email'   => $order->get_billing_email(),
+			'address' => array(
+				'address_1' => $address['address_1'] ?? '',
+				'address_2' => $address['address_2'] ?? '',
+				'city'      => $address['city'] ?? '',
+				'state'     => $address['state'] ?? '',
+				'postcode'  => $address['postcode'] ?? '',
+				'country'   => $address['country'] ?? '',
+			),
+		),
+		'items'           => $items,
+		'artist_payout'   => (float) ( $artist_payout['artist_payout'] ?? 0 ),
+		'order_total'     => (float) ( $artist_payout['total'] ?? 0 ),
+		'tracking_number' => $tracking_number,
+		'ships_free_only' => $ships_free_only,
+	);
+}

--- a/inc/abilities/shop-list-products.php
+++ b/inc/abilities/shop-list-products.php
@@ -1,0 +1,241 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-list-products
+ *
+ * List products belonging to the current user's artist profiles.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_list_products_ability' );
+
+/**
+ * Register the shop-list-products ability.
+ */
+function extrachill_shop_register_list_products_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-list-products',
+		array(
+			'label'       => __( 'List Shop Products', 'extrachill-shop' ),
+			'description' => __( 'List products belonging to the current user\'s artist profiles.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(),
+			),
+			'output_schema' => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'object' ),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_list_products',
+			'permission_callback' => static function (): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_has_artists' ) ) {
+					if ( ! extrachill_api_shop_user_has_artists() ) {
+						return new WP_Error( 'rest_forbidden', 'You must be an artist to manage products.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				return current_user_can( 'manage_options' );
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * List products for current user's artists.
+ *
+ * @param array $input Ability input (unused).
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_list_products( array $input ): array|WP_Error {
+	$artist_ids = function_exists( 'extrachill_api_shop_get_user_artist_ids' )
+		? extrachill_api_shop_get_user_artist_ids()
+		: array();
+
+	$query_args = array(
+		'post_type'      => 'product',
+		'post_status'    => array( 'publish', 'pending', 'draft' ),
+		'posts_per_page' => -1,
+	);
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		if ( empty( $artist_ids ) ) {
+			return array();
+		}
+
+		$artist_ids               = array_map( 'absint', $artist_ids );
+		$query_args['meta_query'] = array(
+			array(
+				'key'     => '_artist_profile_id',
+				'value'   => $artist_ids,
+				'compare' => 'IN',
+				'type'    => 'NUMERIC',
+			),
+		);
+	}
+
+	$query    = new WP_Query( $query_args );
+	$products = $query->posts;
+	$response = array();
+
+	foreach ( $products as $product_post ) {
+		$product_response = extrachill_shop_ability_build_product_response( $product_post->ID );
+		if ( is_wp_error( $product_response ) ) {
+			return $product_response;
+		}
+		$response[] = $product_response;
+	}
+
+	return $response;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build product response object.
+ *
+ * @param int $product_id Product ID.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_build_product_response( int $product_id ): array|WP_Error {
+	$product_post = get_post( $product_id );
+	if ( ! $product_post || 'product' !== $product_post->post_type ) {
+		return new WP_Error( 'product_not_found', 'Product not found.', array( 'status' => 404 ) );
+	}
+
+	$artist_id = get_post_meta( $product_id, '_artist_profile_id', true );
+
+	$image_id  = (int) get_post_thumbnail_id( $product_id );
+	$image_url = $image_id ? (string) wp_get_attachment_image_url( $image_id, 'medium' ) : '';
+
+	$gallery_raw = (string) get_post_meta( $product_id, '_product_image_gallery', true );
+	$gallery_ids = array();
+	if ( $gallery_raw ) {
+		$gallery_ids = array_filter( array_map( 'absint', explode( ',', $gallery_raw ) ) );
+	}
+
+	$gallery_urls = array();
+	$images       = array();
+
+	if ( $image_id ) {
+		$images[] = array(
+			'id'  => $image_id,
+			'url' => (string) wp_get_attachment_image_url( $image_id, 'thumbnail' ),
+		);
+	}
+
+	foreach ( $gallery_ids as $gid ) {
+		$url = (string) wp_get_attachment_image_url( $gid, 'thumbnail' );
+		$gallery_urls[] = array(
+			'id'  => $gid,
+			'url' => $url,
+		);
+		$images[] = array(
+			'id'  => $gid,
+			'url' => $url,
+		);
+	}
+
+	$regular_price = get_post_meta( $product_id, '_regular_price', true );
+	$sale_price    = get_post_meta( $product_id, '_sale_price', true );
+	$manage_stock  = 'yes' === get_post_meta( $product_id, '_manage_stock', true );
+	$stock         = get_post_meta( $product_id, '_stock', true );
+
+	$sizes = extrachill_shop_ability_get_product_sizes( $product_id );
+
+	$stock_quantity = null;
+	if ( ! empty( $sizes ) ) {
+		$stock_quantity = array_reduce(
+			$sizes,
+			static function ( int $sum, array $size ): int {
+				return $sum + ( is_numeric( $size['stock'] ) ? (int) $size['stock'] : 0 );
+			},
+			0
+		);
+		$manage_stock = true;
+	} elseif ( $manage_stock ) {
+		$stock_quantity = '' !== $stock ? (int) $stock : 0;
+	}
+
+	return array(
+		'id'             => $product_id,
+		'name'           => $product_post->post_title,
+		'description'    => $product_post->post_content,
+		'price'          => $regular_price,
+		'sale_price'     => $sale_price,
+		'manage_stock'   => $manage_stock,
+		'stock_quantity' => $stock_quantity,
+		'status'         => get_post_status( $product_id ),
+		'permalink'      => (string) get_permalink( $product_id ),
+		'artist_id'      => $artist_id ? (int) $artist_id : null,
+		'image'          => array(
+			'id'  => $image_id,
+			'url' => $image_url,
+		),
+		'gallery'        => $gallery_urls,
+		'images'         => $images,
+		'sizes'          => $sizes,
+		'ships_free'     => '1' === get_post_meta( $product_id, '_ships_free', true ),
+	);
+}
+
+/**
+ * Get product size variations with stock.
+ *
+ * @param int $product_id Product ID.
+ * @return array
+ */
+function extrachill_shop_ability_get_product_sizes( int $product_id ): array {
+	$product_type = wp_get_object_terms( $product_id, 'product_type', array( 'fields' => 'slugs' ) );
+	if ( is_wp_error( $product_type ) || ! in_array( 'variable', $product_type, true ) ) {
+		return array();
+	}
+
+	$variations = get_posts( array(
+		'post_type'   => 'product_variation',
+		'post_parent' => $product_id,
+		'post_status' => array( 'publish', 'private' ),
+		'numberposts' => -1,
+		'orderby'     => 'menu_order',
+		'order'       => 'ASC',
+	) );
+
+	$sizes = array();
+	foreach ( $variations as $variation ) {
+		$size_attr = get_post_meta( $variation->ID, 'attribute_pa_size', true );
+		if ( ! $size_attr ) {
+			continue;
+		}
+
+		$term      = get_term_by( 'slug', $size_attr, 'pa_size' );
+		$size_name = $term ? $term->name : $size_attr;
+		$stock     = get_post_meta( $variation->ID, '_stock', true );
+
+		$sizes[] = array(
+			'name'  => $size_name,
+			'stock' => '' !== $stock ? (int) $stock : 0,
+		);
+	}
+
+	return $sizes;
+}

--- a/inc/abilities/shop-list-shipping-labels.php
+++ b/inc/abilities/shop-list-shipping-labels.php
@@ -1,0 +1,141 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-list-shipping-labels
+ *
+ * List shipping labels across orders for a given artist.
+ * Canonical implementation — no existing REST route; this is a new
+ * shop-domain ability.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_list_shipping_labels_ability' );
+
+/**
+ * Register the shop-list-shipping-labels ability.
+ */
+function extrachill_shop_register_list_shipping_labels_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-list-shipping-labels',
+		array(
+			'label'       => __( 'List Shipping Labels', 'extrachill-shop' ),
+			'description' => __( 'List all shipping labels purchased for a given artist across their orders.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'artist_id' => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID.',
+					),
+				),
+				'required' => array( 'artist_id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'labels' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'object' ),
+					),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_list_shipping_labels',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				$artist_id = isset( $input['artist_id'] ) ? (int) $input['artist_id'] : 0;
+				if ( ! $artist_id ) {
+					return new WP_Error( 'missing_artist_id', 'Artist ID is required.', array( 'status' => 400 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this artist.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return current_user_can( 'manage_options' );
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * List shipping labels for an artist.
+ *
+ * Scans all completed/processing orders that have artist payouts,
+ * and returns label data for those that have a purchased label.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_list_shipping_labels( array $input ): array|WP_Error {
+	$artist_id = (int) ( $input['artist_id'] ?? 0 );
+
+	if ( ! function_exists( 'wc_get_orders' ) ) {
+		return new WP_Error( 'woocommerce_missing', 'WooCommerce is not available.', array( 'status' => 500 ) );
+	}
+
+	$orders = wc_get_orders( array(
+		'limit'      => -1,
+		'status'     => array( 'wc-processing', 'wc-completed', 'wc-refunded', 'wc-on-hold' ),
+		'orderby'    => 'date',
+		'order'      => 'DESC',
+		'meta_query' => array(
+			array(
+				'key'     => '_artist_payouts',
+				'compare' => 'EXISTS',
+			),
+		),
+	) );
+
+	$labels = array();
+
+	foreach ( $orders as $order ) {
+		$payouts = $order->get_meta( '_artist_payouts' ) ?: array();
+		if ( ! isset( $payouts[ $artist_id ] ) ) {
+			continue;
+		}
+
+		$label_url = $order->get_meta( '_artist_label_' . $artist_id ) ?: '';
+		if ( empty( $label_url ) ) {
+			continue;
+		}
+
+		$tracking_number = $order->get_meta( '_artist_tracking_' . $artist_id ) ?: '';
+		$label_data      = $order->get_meta( '_artist_label_data_' . $artist_id ) ?: array();
+
+		$labels[] = array(
+			'order_id'        => $order->get_id(),
+			'order_number'    => $order->get_order_number(),
+			'artist_id'       => $artist_id,
+			'label_url'       => $label_url,
+			'tracking_number' => $tracking_number,
+			'carrier'         => $label_data['carrier'] ?? '',
+			'service'         => $label_data['service'] ?? '',
+			'cost'            => $label_data['cost'] ?? 0,
+			'purchased_at'    => $label_data['purchased_at'] ?? '',
+		);
+	}
+
+	return array( 'labels' => $labels );
+}

--- a/inc/abilities/shop-refund-order.php
+++ b/inc/abilities/shop-refund-order.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-refund-order
+ *
+ * Issue a full refund for an artist's portion of an order.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_refund_order_ability' );
+
+/**
+ * Register the shop-refund-order ability.
+ */
+function extrachill_shop_register_refund_order_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-refund-order',
+		array(
+			'label'       => __( 'Refund Shop Order', 'extrachill-shop' ),
+			'description' => __( 'Issue a full Stripe refund for an artist\'s portion of an order.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'        => array(
+						'type'        => 'integer',
+						'description' => 'Order ID.',
+					),
+					'artist_id' => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID.',
+					),
+				),
+				'required' => array( 'id', 'artist_id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'success'       => array( 'type' => 'boolean' ),
+					'order_id'      => array( 'type' => 'integer' ),
+					'refund_amount' => array( 'type' => 'number' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_refund_order',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				$artist_id = isset( $input['artist_id'] ) ? (int) $input['artist_id'] : 0;
+				if ( ! $artist_id ) {
+					return new WP_Error( 'missing_artist_id', 'Artist ID is required.', array( 'status' => 400 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this artist.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return current_user_can( 'manage_options' );
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => false,
+					'destructive' => true,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Issue a full refund for the artist's portion of an order.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_refund_order( array $input ): array|WP_Error {
+	$order_id  = (int) ( $input['id'] ?? 0 );
+	$artist_id = (int) ( $input['artist_id'] ?? 0 );
+
+	if ( ! function_exists( 'wc_get_order' ) ) {
+		return new WP_Error( 'woocommerce_missing', 'WooCommerce is not available.', array( 'status' => 500 ) );
+	}
+
+	$order = wc_get_order( $order_id );
+	if ( ! $order ) {
+		return new WP_Error( 'order_not_found', 'Order not found.', array( 'status' => 404 ) );
+	}
+
+	$payouts = $order->get_meta( '_artist_payouts' ) ?: array();
+	if ( ! isset( $payouts[ $artist_id ] ) ) {
+		return new WP_Error( 'invalid_artist', 'This order does not contain products from your artist.', array( 'status' => 400 ) );
+	}
+
+	$artist_payout = $payouts[ $artist_id ];
+	$refund_amount = (float) ( $artist_payout['total'] ?? 0 );
+
+	if ( $refund_amount <= 0 ) {
+		return new WP_Error( 'invalid_refund_amount', 'No refundable amount found for this artist.', array( 'status' => 400 ) );
+	}
+
+	$charges            = $order->get_meta( '_stripe_charges' ) ?: array();
+	$payment_intent_id  = $charges[ $artist_id ]['payment_intent_id'] ?? '';
+
+	if ( ! $payment_intent_id ) {
+		return new WP_Error( 'no_payment_intent', 'No payment intent found for this artist order.', array( 'status' => 400 ) );
+	}
+
+	if ( ! function_exists( 'extrachill_shop_stripe_init' ) || ! extrachill_shop_stripe_init() ) {
+		return new WP_Error( 'stripe_not_configured', 'Stripe is not configured.', array( 'status' => 500 ) );
+	}
+
+	try {
+		\Stripe\Refund::create( array(
+			'payment_intent' => $payment_intent_id,
+		) );
+	} catch ( \Exception $e ) {
+		return new WP_Error( 'refund_failed', 'Refund failed: ' . $e->getMessage(), array( 'status' => 500 ) );
+	}
+
+	$order->set_status( 'refunded', 'Full refund issued by artist.' );
+	$order->save();
+
+	return array(
+		'success'       => true,
+		'order_id'      => $order_id,
+		'refund_amount' => $refund_amount,
+	);
+}

--- a/inc/abilities/shop-stripe-dashboard-link.php
+++ b/inc/abilities/shop-stripe-dashboard-link.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-stripe-dashboard-link
+ *
+ * Generate a Stripe Express dashboard login link for an artist.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_stripe_dashboard_link_ability' );
+
+/**
+ * Register the shop-stripe-dashboard-link ability.
+ */
+function extrachill_shop_register_stripe_dashboard_link_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-stripe-dashboard-link',
+		array(
+			'label'       => __( 'Stripe Dashboard Link', 'extrachill-shop' ),
+			'description' => __( 'Generate a Stripe Express dashboard login link for an artist\'s connected account.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'artist_id' => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID.',
+					),
+				),
+				'required' => array( 'artist_id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'success' => array( 'type' => 'boolean' ),
+					'url'     => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_stripe_dashboard_link',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_not_logged_in', 'You must be logged in to access this endpoint.', array( 'status' => 401 ) );
+				}
+				$artist_id = isset( $input['artist_id'] ) ? (int) $input['artist_id'] : 0;
+				if ( ! $artist_id ) {
+					return new WP_Error( 'missing_artist_id', 'Artist ID is required.', array( 'status' => 400 ) );
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
+						return new WP_Error( 'cannot_manage_artist', 'You do not have access to this artist.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				return current_user_can( 'manage_options' );
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Generate a Stripe dashboard link for the artist.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_stripe_dashboard_link( array $input ): array|WP_Error {
+	$artist_id = (int) ( $input['artist_id'] ?? 0 );
+
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		return new WP_Error( 'configuration_error', 'Artist blog is not configured.', array( 'status' => 500 ) );
+	}
+
+	$artist_blog_id = ec_get_blog_id( 'artist' );
+	if ( ! $artist_blog_id ) {
+		return new WP_Error( 'configuration_error', 'Artist blog is not configured.', array( 'status' => 500 ) );
+	}
+
+	switch_to_blog( $artist_blog_id );
+	try {
+		$account_id = (string) get_post_meta( $artist_id, '_stripe_connect_account_id', true );
+	} finally {
+		restore_current_blog();
+	}
+
+	if ( empty( $account_id ) ) {
+		return new WP_Error( 'no_stripe_account', 'No Stripe account connected.', array( 'status' => 400 ) );
+	}
+
+	if ( ! function_exists( 'extrachill_shop_create_dashboard_link' ) ) {
+		return new WP_Error( 'stripe_not_available', 'Stripe integration is not available.', array( 'status' => 500 ) );
+	}
+
+	$link_result = extrachill_shop_create_dashboard_link( $account_id );
+
+	if ( ! $link_result['success'] ) {
+		return new WP_Error( 'stripe_dashboard_link_failed', $link_result['error'], array( 'status' => 500 ) );
+	}
+
+	return array(
+		'success' => true,
+		'url'     => $link_result['url'],
+	);
+}

--- a/inc/abilities/shop-stripe-onboarding-link.php
+++ b/inc/abilities/shop-stripe-onboarding-link.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-stripe-onboarding-link
+ *
+ * Generate a Stripe Connect onboarding link for an artist. Creates
+ * the Stripe account if it doesn't exist yet.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_stripe_onboarding_link_ability' );
+
+/**
+ * Register the shop-stripe-onboarding-link ability.
+ */
+function extrachill_shop_register_stripe_onboarding_link_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-stripe-onboarding-link',
+		array(
+			'label'       => __( 'Stripe Onboarding Link', 'extrachill-shop' ),
+			'description' => __( 'Generate a Stripe Connect onboarding link for an artist. Creates the account if needed.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'artist_id' => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID.',
+					),
+				),
+				'required' => array( 'artist_id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'success' => array( 'type' => 'boolean' ),
+					'url'     => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_stripe_onboarding_link',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_not_logged_in', 'You must be logged in to access this endpoint.', array( 'status' => 401 ) );
+				}
+				$artist_id = isset( $input['artist_id'] ) ? (int) $input['artist_id'] : 0;
+				if ( ! $artist_id ) {
+					return new WP_Error( 'missing_artist_id', 'Artist ID is required.', array( 'status' => 400 ) );
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
+						return new WP_Error( 'cannot_manage_artist', 'You do not have access to this artist.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				return current_user_can( 'manage_options' );
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => false,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Generate a Stripe onboarding link for the artist.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_stripe_onboarding_link( array $input ): array|WP_Error {
+	$artist_id = (int) ( $input['artist_id'] ?? 0 );
+
+	if ( ! function_exists( 'extrachill_shop_create_stripe_account' ) ) {
+		return new WP_Error( 'stripe_not_available', 'Stripe integration is not available.', array( 'status' => 500 ) );
+	}
+
+	$result = extrachill_shop_create_stripe_account( $artist_id );
+	if ( ! $result['success'] ) {
+		return new WP_Error( 'stripe_account_creation_failed', $result['error'], array( 'status' => 500 ) );
+	}
+
+	$account_id = $result['account_id'];
+
+	if ( ! function_exists( 'extrachill_shop_create_account_link' ) ) {
+		return new WP_Error( 'stripe_not_available', 'Stripe integration is not available.', array( 'status' => 500 ) );
+	}
+
+	$link_result = extrachill_shop_create_account_link( $account_id, 'account_onboarding' );
+
+	if ( ! $link_result['success'] ) {
+		return new WP_Error( 'stripe_link_creation_failed', $link_result['error'], array( 'status' => 500 ) );
+	}
+
+	return array(
+		'success' => true,
+		'url'     => $link_result['url'],
+	);
+}

--- a/inc/abilities/shop-stripe-status.php
+++ b/inc/abilities/shop-stripe-status.php
@@ -1,0 +1,156 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-stripe-status
+ *
+ * Get the Stripe Connect account status for an artist.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_stripe_status_ability' );
+
+/**
+ * Register the shop-stripe-status ability.
+ */
+function extrachill_shop_register_stripe_status_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-stripe-status',
+		array(
+			'label'       => __( 'Stripe Connect Status', 'extrachill-shop' ),
+			'description' => __( 'Get the Stripe Connect account status for an artist.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'artist_id' => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID.',
+					),
+				),
+				'required' => array( 'artist_id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'connected'            => array( 'type' => 'boolean' ),
+					'account_id'           => array(
+						'anyOf' => array(
+							array( 'type' => 'string' ),
+							array( 'type' => 'null' ),
+						),
+					),
+					'status'               => array(
+						'anyOf' => array(
+							array( 'type' => 'string' ),
+							array( 'type' => 'null' ),
+						),
+					),
+					'can_receive_payments' => array( 'type' => 'boolean' ),
+					'charges_enabled'      => array( 'type' => 'boolean' ),
+					'payouts_enabled'      => array( 'type' => 'boolean' ),
+					'details_submitted'    => array( 'type' => 'boolean' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_stripe_status',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_not_logged_in', 'You must be logged in to access this endpoint.', array( 'status' => 401 ) );
+				}
+				$artist_id = isset( $input['artist_id'] ) ? (int) $input['artist_id'] : 0;
+				if ( ! $artist_id ) {
+					return new WP_Error( 'missing_artist_id', 'Artist ID is required.', array( 'status' => 400 ) );
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
+						return new WP_Error( 'cannot_manage_artist', 'You do not have access to this artist.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				return current_user_can( 'manage_options' );
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Get Stripe Connect status for an artist.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_stripe_status( array $input ): array|WP_Error {
+	$artist_id = (int) ( $input['artist_id'] ?? 0 );
+
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		return new WP_Error( 'configuration_error', 'Artist blog is not configured.', array( 'status' => 500 ) );
+	}
+
+	$artist_blog_id = ec_get_blog_id( 'artist' );
+	if ( ! $artist_blog_id ) {
+		return new WP_Error( 'configuration_error', 'Artist blog is not configured.', array( 'status' => 500 ) );
+	}
+
+	switch_to_blog( $artist_blog_id );
+	try {
+		$account_id = (string) get_post_meta( $artist_id, '_stripe_connect_account_id', true );
+	} finally {
+		restore_current_blog();
+	}
+
+	if ( empty( $account_id ) ) {
+		return array(
+			'connected'            => false,
+			'account_id'           => null,
+			'status'               => null,
+			'can_receive_payments' => false,
+		);
+	}
+
+	if ( ! function_exists( 'extrachill_shop_get_account_status' ) ) {
+		return new WP_Error( 'stripe_not_available', 'Stripe integration is not available.', array( 'status' => 500 ) );
+	}
+
+	$status = extrachill_shop_get_account_status( $account_id );
+
+	if ( ! $status['success'] ) {
+		return new WP_Error( 'stripe_status_check_failed', $status['error'], array( 'status' => 500 ) );
+	}
+
+	$safe_status = isset( $status['status'] ) ? (string) $status['status'] : '';
+	if ( $safe_status ) {
+		switch_to_blog( $artist_blog_id );
+		try {
+			update_post_meta( $artist_id, '_stripe_connect_status', $safe_status );
+			update_post_meta( $artist_id, '_stripe_connect_onboarding_complete', ! empty( $status['details_submitted'] ) ? '1' : '0' );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	return array(
+		'connected'            => true,
+		'account_id'           => $account_id,
+		'status'               => $safe_status,
+		'can_receive_payments' => ! empty( $status['can_receive_payments'] ),
+		'charges_enabled'      => ! empty( $status['charges_enabled'] ),
+		'payouts_enabled'      => ! empty( $status['payouts_enabled'] ),
+		'details_submitted'    => ! empty( $status['details_submitted'] ),
+	);
+}

--- a/inc/abilities/shop-taxonomy-counts.php
+++ b/inc/abilities/shop-taxonomy-counts.php
@@ -1,0 +1,207 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-taxonomy-counts
+ *
+ * Return taxonomy term counts for shop products.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_taxonomy_counts_ability' );
+
+/**
+ * Register the shop-taxonomy-counts ability.
+ */
+function extrachill_shop_register_taxonomy_counts_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-taxonomy-counts',
+		array(
+			'label'       => __( 'Shop Taxonomy Counts', 'extrachill-shop' ),
+			'description' => __( 'Return taxonomy term counts for shop products. Supports querying by slug or bulk listing.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'taxonomy' => array(
+						'type'        => 'string',
+						'enum'        => array( 'artist' ),
+						'description' => 'Taxonomy to query (currently only artist supported).',
+					),
+					'slug'     => array(
+						'type'        => 'string',
+						'description' => 'Specific term slug. If provided, returns single term data.',
+					),
+					'limit'    => array(
+						'type'        => 'integer',
+						'default'     => 8,
+						'minimum'     => 1,
+						'maximum'     => 50,
+						'description' => 'Max terms to return for bulk queries.',
+					),
+				),
+				'required' => array( 'taxonomy' ),
+			),
+			'output_schema' => array(
+				'anyOf' => array(
+					array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'object' ),
+					),
+					array( 'type' => 'object' ),
+					array( 'type' => 'null' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_taxonomy_counts',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Return taxonomy term counts.
+ *
+ * @param array $input Ability input.
+ * @return array|null|WP_Error
+ */
+function extrachill_shop_ability_taxonomy_counts( array $input ): array|null|WP_Error {
+	$taxonomy = (string) ( $input['taxonomy'] ?? 'artist' );
+	$slug     = isset( $input['slug'] ) ? sanitize_title( (string) $input['slug'] ) : '';
+	$limit    = (int) ( $input['limit'] ?? 8 );
+	$limit    = max( 1, min( 50, $limit ) );
+
+	// Single term query.
+	if ( ! empty( $slug ) ) {
+		return extrachill_shop_ability_get_single_term_count( $slug, $taxonomy );
+	}
+
+	// Bulk query — check transient cache first.
+	$cache_key = 'ec_shop_counts_' . $taxonomy;
+	$cached    = get_transient( $cache_key );
+
+	if ( false !== $cached && is_array( $cached ) ) {
+		return array_slice( $cached, 0, $limit );
+	}
+
+	// Cold cache — delegate to existing ability if available.
+	$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/taxonomy-post-counts' ) : null;
+
+	if ( $ability ) {
+		$result = $ability->execute( array(
+			'taxonomy'  => $taxonomy,
+			'site'      => 'shop',
+			'post_type' => 'product',
+		) );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$terms = $result['terms'] ?? array();
+		set_transient( $cache_key, $terms, 6 * HOUR_IN_SECONDS );
+
+		return array_slice( $terms, 0, $limit );
+	}
+
+	// Fallback: query terms directly.
+	if ( ! taxonomy_exists( $taxonomy ) ) {
+		return array();
+	}
+
+	$terms = get_terms( array(
+		'taxonomy'   => $taxonomy,
+		'hide_empty' => true,
+		'number'     => $limit,
+		'orderby'    => 'count',
+		'order'      => 'DESC',
+	) );
+
+	if ( is_wp_error( $terms ) ) {
+		return $terms;
+	}
+
+	$result = array();
+	foreach ( $terms as $term ) {
+		$url = get_term_link( $term );
+		if ( is_wp_error( $url ) ) {
+			continue;
+		}
+		$result[] = array(
+			'term_id' => $term->term_id,
+			'slug'    => $term->slug,
+			'name'    => $term->name,
+			'count'   => $term->count,
+			'url'     => $url,
+		);
+	}
+
+	set_transient( $cache_key, $result, 6 * HOUR_IN_SECONDS );
+
+	return array_slice( $result, 0, $limit );
+}
+
+/**
+ * Get product count for a single term.
+ *
+ * @param string $slug     Term slug.
+ * @param string $taxonomy Taxonomy slug.
+ * @return array|null Term data or null.
+ */
+function extrachill_shop_ability_get_single_term_count( string $slug, string $taxonomy ): ?array {
+	if ( ! taxonomy_exists( $taxonomy ) ) {
+		return null;
+	}
+
+	$term = get_term_by( 'slug', $slug, $taxonomy );
+	if ( ! $term || is_wp_error( $term ) ) {
+		return null;
+	}
+
+	$query = new WP_Query( array(
+		'post_type'      => 'product',
+		'post_status'    => 'publish',
+		'posts_per_page' => 1,
+		'fields'         => 'ids',
+		'no_found_rows'  => false,
+		'tax_query'      => array(
+			array(
+				'taxonomy' => $taxonomy,
+				'field'    => 'term_id',
+				'terms'    => $term->term_id,
+			),
+		),
+	) );
+
+	if ( $query->found_posts < 1 ) {
+		return null;
+	}
+
+	$url = get_term_link( $term );
+	if ( is_wp_error( $url ) ) {
+		return null;
+	}
+
+	return array(
+		'term_id' => $term->term_id,
+		'slug'    => $term->slug,
+		'name'    => $term->name,
+		'count'   => $query->found_posts,
+		'url'     => $url,
+	);
+}

--- a/inc/abilities/shop-update-order-status.php
+++ b/inc/abilities/shop-update-order-status.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-update-order-status
+ *
+ * Update the status of an order (e.g. mark as shipped/completed).
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_update_order_status_ability' );
+
+/**
+ * Register the shop-update-order-status ability.
+ */
+function extrachill_shop_register_update_order_status_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-update-order-status',
+		array(
+			'label'       => __( 'Update Order Status', 'extrachill-shop' ),
+			'description' => __( 'Update the status of an order, optionally adding a tracking number.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'              => array(
+						'type'        => 'integer',
+						'description' => 'Order ID.',
+					),
+					'artist_id'       => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID.',
+					),
+					'status'          => array(
+						'type'        => 'string',
+						'enum'        => array( 'completed' ),
+						'description' => 'New order status.',
+					),
+					'tracking_number' => array(
+						'type'        => 'string',
+						'description' => 'Optional tracking number.',
+					),
+				),
+				'required' => array( 'id', 'artist_id', 'status' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'              => array( 'type' => 'integer' ),
+					'status'          => array( 'type' => 'string' ),
+					'tracking_number' => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_update_order_status',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				$artist_id = isset( $input['artist_id'] ) ? (int) $input['artist_id'] : 0;
+				if ( ! $artist_id ) {
+					return new WP_Error( 'missing_artist_id', 'Artist ID is required.', array( 'status' => 400 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this artist.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return current_user_can( 'manage_options' );
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Update order status for an artist.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_update_order_status( array $input ): array|WP_Error {
+	$order_id        = (int) ( $input['id'] ?? 0 );
+	$artist_id       = (int) ( $input['artist_id'] ?? 0 );
+	$new_status      = (string) ( $input['status'] ?? '' );
+	$tracking_number = isset( $input['tracking_number'] ) ? sanitize_text_field( (string) $input['tracking_number'] ) : '';
+
+	if ( ! function_exists( 'wc_get_order' ) ) {
+		return new WP_Error( 'woocommerce_missing', 'WooCommerce is not available.', array( 'status' => 500 ) );
+	}
+
+	$order = wc_get_order( $order_id );
+	if ( ! $order ) {
+		return new WP_Error( 'order_not_found', 'Order not found.', array( 'status' => 404 ) );
+	}
+
+	$payouts = $order->get_meta( '_artist_payouts' ) ?: array();
+	if ( ! isset( $payouts[ $artist_id ] ) ) {
+		return new WP_Error( 'rest_forbidden', 'This order does not contain products from your artist.', array( 'status' => 403 ) );
+	}
+
+	if ( $tracking_number ) {
+		$order->update_meta_data( '_artist_tracking_' . $artist_id, $tracking_number );
+	}
+
+	if ( 'completed' === $new_status ) {
+		$order->set_status( 'completed', 'Order marked as shipped by artist.' );
+	}
+
+	$order->save();
+
+	return extrachill_shop_ability_build_order_response( $order, $artist_id );
+}

--- a/inc/abilities/shop-update-shipping-address.php
+++ b/inc/abilities/shop-update-shipping-address.php
@@ -1,0 +1,154 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-update-shipping-address
+ *
+ * Update an artist's shipping from-address.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_update_shipping_address_ability' );
+
+/**
+ * Register the shop-update-shipping-address ability.
+ */
+function extrachill_shop_register_update_shipping_address_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-update-shipping-address',
+		array(
+			'label'       => __( 'Update Shipping Address', 'extrachill-shop' ),
+			'description' => __( 'Update an artist\'s shipping from-address.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'artist_id' => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID.',
+					),
+					'name'      => array(
+						'type'        => 'string',
+						'description' => 'Full name.',
+					),
+					'street1'   => array(
+						'type'        => 'string',
+						'description' => 'Street address line 1.',
+					),
+					'street2'   => array(
+						'type'        => 'string',
+						'description' => 'Street address line 2.',
+					),
+					'city'      => array(
+						'type'        => 'string',
+						'description' => 'City.',
+					),
+					'state'     => array(
+						'type'        => 'string',
+						'description' => 'State.',
+					),
+					'zip'       => array(
+						'type'        => 'string',
+						'description' => 'ZIP code.',
+					),
+					'country'   => array(
+						'type'        => 'string',
+						'default'     => 'US',
+						'description' => 'Country code.',
+					),
+				),
+				'required' => array( 'artist_id', 'name', 'street1', 'city', 'state', 'zip' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'success'   => array( 'type' => 'boolean' ),
+					'artist_id' => array( 'type' => 'integer' ),
+					'address'   => array( 'type' => 'object' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_update_shipping_address',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				$artist_id = isset( $input['artist_id'] ) ? (int) $input['artist_id'] : 0;
+				if ( ! $artist_id ) {
+					return new WP_Error( 'missing_artist_id', 'Artist ID is required.', array( 'status' => 400 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this artist.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return current_user_can( 'manage_options' );
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Update artist shipping address.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_update_shipping_address( array $input ): array|WP_Error {
+	$artist_id = (int) ( $input['artist_id'] ?? 0 );
+
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		return new WP_Error( 'configuration_error', 'Multisite plugin is not active.', array( 'status' => 500 ) );
+	}
+
+	$artist_blog_id = ec_get_blog_id( 'artist' );
+	if ( ! $artist_blog_id ) {
+		return new WP_Error( 'configuration_error', 'Artist blog is not configured.', array( 'status' => 500 ) );
+	}
+
+	$address = array(
+		'name'    => sanitize_text_field( (string) ( $input['name'] ?? '' ) ),
+		'street1' => sanitize_text_field( (string) ( $input['street1'] ?? '' ) ),
+		'street2' => sanitize_text_field( (string) ( $input['street2'] ?? '' ) ),
+		'city'    => sanitize_text_field( (string) ( $input['city'] ?? '' ) ),
+		'state'   => strtoupper( sanitize_text_field( (string) ( $input['state'] ?? '' ) ) ),
+		'zip'     => sanitize_text_field( (string) ( $input['zip'] ?? '' ) ),
+		'country' => 'US',
+	);
+
+	switch_to_blog( $artist_blog_id );
+	try {
+		$result = update_post_meta( $artist_id, '_shipping_address', $address );
+	} finally {
+		restore_current_blog();
+	}
+
+	if ( false === $result ) {
+		return new WP_Error( 'save_failed', 'Failed to save shipping address.', array( 'status' => 500 ) );
+	}
+
+	return array(
+		'success'   => true,
+		'artist_id' => $artist_id,
+		'address'   => $address,
+	);
+}

--- a/inc/abilities/shop-upload-product-image.php
+++ b/inc/abilities/shop-upload-product-image.php
@@ -1,0 +1,242 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-upload-product-image
+ *
+ * Upload one or more images to a product.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_upload_product_image_ability' );
+
+/**
+ * Register the shop-upload-product-image ability.
+ */
+function extrachill_shop_register_upload_product_image_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-upload-product-image',
+		array(
+			'label'       => __( 'Upload Product Image', 'extrachill-shop' ),
+			'description' => __( 'Upload one or more images to a product (max 5 total). First image becomes the featured image; the rest go to the gallery.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'    => array(
+						'type'        => 'integer',
+						'description' => 'Product ID.',
+					),
+					'files' => array(
+						'type'        => 'array',
+						'description' => 'File upload data (handled by transport layer).',
+						'items'       => array( 'type' => 'object' ),
+					),
+				),
+				'required' => array( 'id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'     => array( 'type' => 'integer' ),
+					'images' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'object' ),
+					),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_upload_product_image',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				if ( current_user_can( 'manage_options' ) ) {
+					return true;
+				}
+				$product_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+				$product_post = get_post( $product_id );
+				if ( ! $product_post || 'product' !== $product_post->post_type ) {
+					return new WP_Error( 'product_not_found', 'Product not found.', array( 'status' => 404 ) );
+				}
+				$artist_id = (int) get_post_meta( $product_id, '_artist_profile_id', true );
+				if ( ! $artist_id ) {
+					return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this product.', array( 'status' => 403 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this product.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return false;
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => false,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Upload images to a product.
+ *
+ * This ability handles the file-upload workflow: it reads from $_FILES,
+ * validates types and sizes, creates WordPress attachments, and updates
+ * the product's featured image and gallery.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_upload_product_image( array $input ): array|WP_Error {
+	$product_id = (int) ( $input['id'] ?? 0 );
+
+	$product_post = get_post( $product_id );
+	if ( ! $product_post || 'product' !== $product_post->post_type ) {
+		return new WP_Error( 'product_not_found', 'Product not found.', array( 'status' => 404 ) );
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce checked by ability layer.
+	$files = $_FILES;
+	if ( empty( $files['files'] ) || empty( $files['files']['name'] ) ) {
+		return new WP_Error( 'no_files', 'No files uploaded.', array( 'status' => 400 ) );
+	}
+
+	$allowed_types = array( 'image/jpeg', 'image/png', 'image/gif', 'image/webp' );
+	$max_size      = 5 * 1024 * 1024;
+
+	// Get current image order.
+	$current_ids = extrachill_shop_ability_get_ordered_image_ids( $product_id );
+	if ( count( $current_ids ) >= 5 ) {
+		return new WP_Error(
+			'image_limit_reached',
+			'You already have five images. Please delete one before uploading another.',
+			array( 'status' => 400 )
+		);
+	}
+
+	$file_count = is_array( $files['files']['name'] ) ? count( $files['files']['name'] ) : 1;
+	$incoming   = array();
+
+	for ( $i = 0; $i < $file_count; $i++ ) {
+		if ( count( $incoming ) + count( $current_ids ) >= 5 ) {
+			break;
+		}
+
+		$uploaded_file = array(
+			'name'     => is_array( $files['files']['name'] ) ? $files['files']['name'][ $i ] : $files['files']['name'],
+			'type'     => is_array( $files['files']['type'] ) ? $files['files']['type'][ $i ] : $files['files']['type'],
+			'tmp_name' => is_array( $files['files']['tmp_name'] ) ? $files['files']['tmp_name'][ $i ] : $files['files']['tmp_name'],
+			'error'    => is_array( $files['files']['error'] ) ? $files['files']['error'][ $i ] : $files['files']['error'],
+			'size'     => is_array( $files['files']['size'] ) ? $files['files']['size'][ $i ] : $files['files']['size'],
+		);
+
+		if ( empty( $uploaded_file['name'] ) ) {
+			continue;
+		}
+
+		$file_type = wp_check_filetype_and_ext( $uploaded_file['tmp_name'], $uploaded_file['name'] );
+		if ( ! in_array( $file_type['type'], $allowed_types, true ) ) {
+			return new WP_Error( 'invalid_file_type', 'Invalid file type. Only JPG, PNG, GIF, and WebP are allowed.', array( 'status' => 400 ) );
+		}
+
+		if ( $uploaded_file['size'] > $max_size ) {
+			return new WP_Error( 'file_too_large', 'File size exceeds the 5MB limit.', array( 'status' => 400 ) );
+		}
+
+		if ( ! function_exists( 'wp_handle_upload' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		$upload_result = wp_handle_upload( $uploaded_file, array( 'test_form' => false ) );
+		if ( ! $upload_result || isset( $upload_result['error'] ) ) {
+			return new WP_Error(
+				'upload_failed',
+				isset( $upload_result['error'] ) ? $upload_result['error'] : 'Upload failed.',
+				array( 'status' => 500 )
+			);
+		}
+
+		$attachment = array(
+			'guid'           => $upload_result['url'],
+			'post_mime_type' => $upload_result['type'],
+			'post_title'     => preg_replace( '/\.[^.]+$/', '', basename( $upload_result['file'] ) ),
+			'post_content'   => '',
+			'post_status'    => 'inherit',
+		);
+
+		$attachment_id = wp_insert_attachment( $attachment, $upload_result['file'], $product_id );
+		if ( is_wp_error( $attachment_id ) ) {
+			return $attachment_id;
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+		$attach_data = wp_generate_attachment_metadata( $attachment_id, $upload_result['file'] );
+		wp_update_attachment_metadata( $attachment_id, $attach_data );
+
+		$incoming[] = (int) $attachment_id;
+	}
+
+	if ( empty( $incoming ) ) {
+		return new WP_Error( 'no_files', 'No files uploaded.', array( 'status' => 400 ) );
+	}
+
+	// Update image order: featured + gallery.
+	$new_order = array_merge( $current_ids, $incoming );
+	$new_order = array_values( array_unique( array_slice( $new_order, 0, 5 ) ) );
+
+	$featured_id = array_shift( $new_order );
+	set_post_thumbnail( $product_id, $featured_id );
+
+	if ( ! empty( $new_order ) ) {
+		update_post_meta( $product_id, '_product_image_gallery', implode( ',', $new_order ) );
+	} else {
+		delete_post_meta( $product_id, '_product_image_gallery' );
+	}
+
+	if ( function_exists( 'extrachill_shop_ability_build_product_response' ) ) {
+		return extrachill_shop_ability_build_product_response( $product_id );
+	}
+
+	return array( 'product_id' => $product_id );
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Get ordered product image attachment IDs.
+ *
+ * @param int $product_id Product ID.
+ * @return int[]
+ */
+function extrachill_shop_ability_get_ordered_image_ids( int $product_id ): array {
+	$featured_id = (int) get_post_thumbnail_id( $product_id );
+	$ids         = array();
+
+	if ( $featured_id ) {
+		$ids[] = $featured_id;
+	}
+
+	$gallery_raw = (string) get_post_meta( $product_id, '_product_image_gallery', true );
+	if ( $gallery_raw ) {
+		$gallery_ids = array_values( array_filter( array_map( 'absint', explode( ',', $gallery_raw ) ) ) );
+		$ids         = array_merge( $ids, $gallery_ids );
+	}
+
+	return array_values( array_unique( $ids ) );
+}


### PR DESCRIPTION
## Summary

- Registers **14 shop-domain abilities** with canonical `execute_callback` implementations
- Covers orders, products, shipping, Stripe Connect, and taxonomy-counts
- Each ability has `meta.show_in_rest: true` and correct `readonly` annotations
- New `inc/abilities/` directory with one file per ability + bootstrap loader

## Abilities registered

| Ability | readonly | File |
|---|---|---|
| `extrachill/shop-list-orders` | true | `shop-list-orders.php` |
| `extrachill/shop-refund-order` | false | `shop-refund-order.php` |
| `extrachill/shop-update-order-status` | false | `shop-update-order-status.php` |
| `extrachill/shop-list-products` | true | `shop-list-products.php` |
| `extrachill/shop-get-product` | true | `shop-get-product.php` |
| `extrachill/shop-upload-product-image` | false | `shop-upload-product-image.php` |
| `extrachill/shop-get-shipping-address` | true | `shop-get-shipping-address.php` |
| `extrachill/shop-update-shipping-address` | false | `shop-update-shipping-address.php` |
| `extrachill/shop-list-shipping-labels` | true | `shop-list-shipping-labels.php` |
| `extrachill/shop-get-shipping-label` | true | `shop-get-shipping-label.php` |
| `extrachill/shop-stripe-dashboard-link` | true | `shop-stripe-dashboard-link.php` |
| `extrachill/shop-stripe-onboarding-link` | true | `shop-stripe-onboarding-link.php` |
| `extrachill/shop-stripe-status` | true | `shop-stripe-status.php` |
| `extrachill/shop-taxonomy-counts` | true | `shop-taxonomy-counts.php` |

## Pattern

Per [WP core's `wp_register_core_abilities()`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/abilities.php), the ability is the source of truth. `execute_callback` IS the canonical implementation — not a wrapper. The branded `/extrachill/v1/shop/*` REST routes in extrachill-api refactor to thin shims separately.

## Verification

- `php -l` passes on all 15 new PHP files
- All files use `declare(strict_types=1)` (PHP 8.1+)
- Permission callbacks match existing REST semantics
- Input/output schemas match response shapes

Closes #4.