### PR TITLE
feat(abilities): register remaining shop abilities

### DIFF
--- a/inc/abilities/register.php
+++ b/inc/abilities/register.php
@@ -42,3 +42,8 @@ require_once __DIR__ . '/shop-stripe-dashboard-link.php';
 require_once __DIR__ . '/shop-stripe-onboarding-link.php';
 require_once __DIR__ . '/shop-stripe-status.php';
 require_once __DIR__ . '/shop-taxonomy-counts.php';
+require_once __DIR__ . '/shop-create-product.php';
+require_once __DIR__ . '/shop-update-product.php';
+require_once __DIR__ . '/shop-delete-product.php';
+require_once __DIR__ . '/shop-delete-product-image.php';
+require_once __DIR__ . '/shop-create-shipping-label.php';

--- a/inc/abilities/shop-create-product.php
+++ b/inc/abilities/shop-create-product.php
@@ -1,0 +1,213 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-create-product
+ *
+ * Create a new WooCommerce product for an artist.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_create_product_ability' );
+
+/**
+ * Register the shop-create-product ability.
+ */
+function extrachill_shop_register_create_product_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-create-product',
+		array(
+			'label'       => __( 'Create Shop Product', 'extrachill-shop' ),
+			'description' => __( 'Create a new WooCommerce product for an artist profile with pricing, stock, sizes, and image associations.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'artist_id'      => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID.',
+					),
+					'name'           => array(
+						'type'        => 'string',
+						'description' => 'Product name.',
+					),
+					'price'          => array(
+						'type'        => 'number',
+						'description' => 'Regular price.',
+					),
+					'sale_price'     => array(
+						'type'        => 'number',
+						'description' => 'Sale price (optional, must be less than price).',
+					),
+					'description'    => array(
+						'type'        => 'string',
+						'description' => 'Product description.',
+					),
+					'manage_stock'   => array(
+						'type'        => 'boolean',
+						'description' => 'Whether to manage stock.',
+					),
+					'stock_quantity' => array(
+						'type'        => 'integer',
+						'description' => 'Stock quantity (when manage_stock is true).',
+					),
+					'image_id'       => array(
+						'type'        => 'integer',
+						'description' => 'Featured image attachment ID.',
+					),
+					'gallery_ids'    => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'integer' ),
+						'description' => 'Gallery image attachment IDs (max 4).',
+					),
+					'sizes'          => array(
+						'type'        => 'array',
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'name'  => array( 'type' => 'string' ),
+								'stock' => array( 'type' => 'integer' ),
+							),
+						),
+						'description' => 'Size variations with stock.',
+					),
+					'ships_free'     => array(
+						'type'        => 'boolean',
+						'description' => 'Whether the product ships free.',
+					),
+				),
+				'required' => array( 'artist_id', 'name', 'price' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'     => array( 'type' => 'integer' ),
+					'name'   => array( 'type' => 'string' ),
+					'price'  => array( 'type' => 'string' ),
+					'status' => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_create_product',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_has_artists' ) ) {
+					if ( ! extrachill_api_shop_user_has_artists() ) {
+						return new WP_Error( 'rest_forbidden', 'You must be an artist to manage products.', array( 'status' => 403 ) );
+					}
+				}
+				$artist_id = isset( $input['artist_id'] ) ? (int) $input['artist_id'] : 0;
+				if ( ! $artist_id ) {
+					return new WP_Error( 'missing_artist_id', 'Artist ID is required.', array( 'status' => 400 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to create products for this artist.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return current_user_can( 'manage_options' );
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => false,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Create a new product for an artist.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_create_product( array $input ): array|WP_Error {
+	$artist_id      = (int) ( $input['artist_id'] ?? 0 );
+	$name           = (string) ( $input['name'] ?? '' );
+	$price          = (float) ( $input['price'] ?? 0 );
+	$sale_price     = isset( $input['sale_price'] ) ? (float) $input['sale_price'] : null;
+	$description    = (string) ( $input['description'] ?? '' );
+	$manage_stock   = (bool) ( $input['manage_stock'] ?? false );
+	$stock_quantity = (int) ( $input['stock_quantity'] ?? 0 );
+	$image_id       = (int) ( $input['image_id'] ?? 0 );
+	$gallery_ids    = isset( $input['gallery_ids'] ) && is_array( $input['gallery_ids'] ) ? array_map( 'absint', $input['gallery_ids'] ) : array();
+	$sizes          = isset( $input['sizes'] ) && is_array( $input['sizes'] ) ? $input['sizes'] : array();
+	$ships_free     = (bool) ( $input['ships_free'] ?? false );
+
+	$product_id = wp_insert_post(
+		array(
+			'post_type'    => 'product',
+			'post_status'  => 'draft',
+			'post_title'   => sanitize_text_field( $name ),
+			'post_content' => $description ? wp_kses_post( wp_unslash( $description ) ) : '',
+		),
+		true
+	);
+
+	if ( is_wp_error( $product_id ) ) {
+		return new WP_Error( 'create_failed', 'Failed to create product.', array( 'status' => 500 ) );
+	}
+
+	update_post_meta( $product_id, '_artist_profile_id', $artist_id );
+	update_post_meta( $product_id, '_regular_price', (string) $price );
+	update_post_meta( $product_id, '_price', (string) $price );
+
+	if ( is_numeric( $sale_price ) && $sale_price > 0 && $sale_price < $price ) {
+		update_post_meta( $product_id, '_sale_price', (string) $sale_price );
+		update_post_meta( $product_id, '_price', (string) $sale_price );
+	} else {
+		delete_post_meta( $product_id, '_sale_price' );
+	}
+
+	update_post_meta( $product_id, '_manage_stock', $manage_stock ? 'yes' : 'no' );
+	update_post_meta( $product_id, '_stock', $manage_stock ? (string) absint( $stock_quantity ) : '' );
+	update_post_meta( $product_id, '_stock_status', 'instock' );
+
+	if ( $image_id ) {
+		set_post_thumbnail( $product_id, $image_id );
+	}
+
+	if ( ! empty( $gallery_ids ) ) {
+		$gallery_ids = array_filter( $gallery_ids );
+		$gallery_ids = array_slice( $gallery_ids, 0, 4 );
+		update_post_meta( $product_id, '_product_image_gallery', implode( ',', $gallery_ids ) );
+	} else {
+		delete_post_meta( $product_id, '_product_image_gallery' );
+	}
+
+	if ( ! empty( $sizes ) && function_exists( 'extrachill_api_shop_setup_product_variations' ) ) {
+		$variation_result = extrachill_api_shop_setup_product_variations( $product_id, $sizes, $price, $sale_price );
+		if ( is_wp_error( $variation_result ) ) {
+			return $variation_result;
+		}
+	}
+
+	if ( function_exists( 'extrachill_api_shop_sync_artist_taxonomy' ) ) {
+		extrachill_api_shop_sync_artist_taxonomy( $product_id, $artist_id );
+	}
+
+	update_post_meta( $product_id, '_ships_free', $ships_free ? '1' : '0' );
+
+	if ( function_exists( 'extrachill_shop_ability_build_product_response' ) ) {
+		return extrachill_shop_ability_build_product_response( $product_id );
+	}
+
+	return array( 'id' => $product_id, 'name' => $name, 'status' => 'draft' );
+}

--- a/inc/abilities/shop-create-shipping-label.php
+++ b/inc/abilities/shop-create-shipping-label.php
@@ -1,0 +1,237 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-create-shipping-label
+ *
+ * Purchase a shipping label for an artist's portion of an order via Shippo.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_create_shipping_label_ability' );
+
+/**
+ * Register the shop-create-shipping-label ability.
+ */
+function extrachill_shop_register_create_shipping_label_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-create-shipping-label',
+		array(
+			'label'       => __( 'Purchase Shipping Label', 'extrachill-shop' ),
+			'description' => __( 'Purchase a USPS shipping label via Shippo for an artist\'s portion of an order. Automatically selects the cheapest rate, updates order status, and emails the label.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'order_id'  => array(
+						'type'        => 'integer',
+						'description' => 'WooCommerce order ID.',
+					),
+					'artist_id' => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID.',
+					),
+				),
+				'required' => array( 'order_id', 'artist_id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'success'         => array( 'type' => 'boolean' ),
+					'order_id'        => array( 'type' => 'integer' ),
+					'artist_id'       => array( 'type' => 'integer' ),
+					'label_url'       => array( 'type' => 'string' ),
+					'tracking_number' => array( 'type' => 'string' ),
+					'carrier'         => array( 'type' => 'string' ),
+					'service'         => array( 'type' => 'string' ),
+					'cost'            => array( 'type' => 'number' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_create_shipping_label',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				$artist_id = isset( $input['artist_id'] ) ? (int) $input['artist_id'] : 0;
+				if ( ! $artist_id ) {
+					return new WP_Error( 'missing_artist_id', 'Artist ID is required.', array( 'status' => 400 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this artist.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return current_user_can( 'manage_options' );
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => false,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Purchase a shipping label for an artist's order items.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_create_shipping_label( array $input ): array|WP_Error {
+	$order_id  = (int) ( $input['order_id'] ?? 0 );
+	$artist_id = (int) ( $input['artist_id'] ?? 0 );
+	$user_id   = get_current_user_id();
+
+	if ( ! function_exists( 'extrachill_api_artist_has_shipping_address' ) ) {
+		return new WP_Error( 'configuration_error', 'Shipping address API not available.', array( 'status' => 500 ) );
+	}
+
+	if ( ! extrachill_api_artist_has_shipping_address( $artist_id ) ) {
+		return new WP_Error(
+			'no_shipping_address',
+			'Please set up your shipping address in the Settings tab before printing labels.',
+			array( 'status' => 400 )
+		);
+	}
+
+	if ( ! function_exists( 'extrachill_shop_is_shippo_configured' ) || ! extrachill_shop_is_shippo_configured() ) {
+		return new WP_Error( 'shippo_not_configured', 'Shipping service is not configured. Please contact support.', array( 'status' => 500 ) );
+	}
+
+	if ( ! function_exists( 'wc_get_order' ) ) {
+		return new WP_Error( 'woocommerce_missing', 'WooCommerce is not available.', array( 'status' => 500 ) );
+	}
+
+	$order = wc_get_order( $order_id );
+	if ( ! $order ) {
+		return new WP_Error( 'order_not_found', 'Order not found.', array( 'status' => 404 ) );
+	}
+
+	$payouts = $order->get_meta( '_artist_payouts' ) ?: array();
+	if ( ! isset( $payouts[ $artist_id ] ) ) {
+		return new WP_Error( 'invalid_artist', 'This order does not contain products from your artist.', array( 'status' => 400 ) );
+	}
+
+	// Check if order contains only ships-free products.
+	if ( function_exists( 'extrachill_api_shop_order_ships_free_only' ) ) {
+		$artist_payout = $payouts[ $artist_id ] ?? array();
+		if ( extrachill_api_shop_order_ships_free_only( $artist_payout ) ) {
+			return new WP_Error(
+				'ships_free_order',
+				'This order contains only "Ships Free" items. No shipping label is needed—ship these items yourself.',
+				array( 'status' => 400 )
+			);
+		}
+	}
+
+	// Return existing label if already purchased.
+	$existing_label = $order->get_meta( '_artist_label_' . $artist_id );
+	if ( ! empty( $existing_label ) ) {
+		$tracking   = $order->get_meta( '_artist_tracking_' . $artist_id ) ?: '';
+		$label_data = $order->get_meta( '_artist_label_data_' . $artist_id ) ?: array();
+
+		return array(
+			'success'         => true,
+			'reprint'         => true,
+			'order_id'        => $order_id,
+			'artist_id'       => $artist_id,
+			'label_url'       => $existing_label,
+			'tracking_number' => $tracking,
+			'carrier'         => $label_data['carrier'] ?? 'USPS',
+			'service'         => $label_data['service'] ?? '',
+			'cost'            => $label_data['cost'] ?? 0,
+		);
+	}
+
+	$from_address = extrachill_api_get_artist_shipping_address( $artist_id );
+
+	$shipping = $order->get_address( 'shipping' );
+	$billing  = $order->get_address( 'billing' );
+	$address  = ! empty( $shipping['address_1'] ) ? $shipping : $billing;
+
+	$to_address = array(
+		'name'    => trim( ( $address['first_name'] ?? '' ) . ' ' . ( $address['last_name'] ?? '' ) ),
+		'street1' => $address['address_1'] ?? '',
+		'street2' => $address['address_2'] ?? '',
+		'city'    => $address['city'] ?? '',
+		'state'   => $address['state'] ?? '',
+		'zip'     => $address['postcode'] ?? '',
+		'country' => $address['country'] ?? 'US',
+	);
+
+	if ( 'US' !== $to_address['country'] ) {
+		return new WP_Error( 'international_not_supported', 'International shipping is not currently supported.', array( 'status' => 400 ) );
+	}
+
+	if ( ! function_exists( 'extrachill_shop_shippo_create_label' ) ) {
+		return new WP_Error( 'shippo_not_available', 'Shippo integration is not available.', array( 'status' => 500 ) );
+	}
+
+	$label_result = extrachill_shop_shippo_create_label( $from_address, $to_address );
+
+	if ( is_wp_error( $label_result ) ) {
+		return $label_result;
+	}
+
+	$order->update_meta_data( '_artist_label_' . $artist_id, $label_result['label_url'] );
+	$order->update_meta_data( '_artist_tracking_' . $artist_id, $label_result['tracking_number'] );
+	$order->update_meta_data( '_artist_label_data_' . $artist_id, array(
+		'carrier'        => $label_result['carrier'],
+		'service'        => $label_result['service'],
+		'cost'           => $label_result['cost'],
+		'tracking_url'   => $label_result['tracking_url'],
+		'rate_id'        => $label_result['rate_id'],
+		'transaction_id' => $label_result['transaction_id'],
+		'purchased_at'   => current_time( 'mysql' ),
+		'purchased_by'   => $user_id,
+	) );
+
+	$order->set_status( 'completed', sprintf(
+		'Shipping label purchased by %s. Tracking: %s',
+		wp_get_current_user()->display_name,
+		$label_result['tracking_number']
+	) );
+	$order->save();
+
+	// Send email notification.
+	$user       = get_userdata( $user_id );
+	$user_email = $user ? $user->user_email : '';
+
+	if ( $user_email && function_exists( 'extrachill_api_send_label_email' ) ) {
+		extrachill_api_send_label_email(
+			$user_email,
+			$order,
+			$artist_id,
+			$label_result,
+			$payouts[ $artist_id ]
+		);
+	}
+
+	return array(
+		'success'         => true,
+		'order_id'        => $order_id,
+		'artist_id'       => $artist_id,
+		'label_url'       => $label_result['label_url'],
+		'tracking_number' => $label_result['tracking_number'],
+		'tracking_url'    => $label_result['tracking_url'] ?? '',
+		'carrier'         => $label_result['carrier'],
+		'service'         => $label_result['service'],
+		'cost'            => $label_result['cost'],
+	);
+}

--- a/inc/abilities/shop-delete-product-image.php
+++ b/inc/abilities/shop-delete-product-image.php
@@ -1,0 +1,180 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-delete-product-image
+ *
+ * Delete a single image from a product.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_delete_product_image_ability' );
+
+/**
+ * Register the shop-delete-product-image ability.
+ */
+function extrachill_shop_register_delete_product_image_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-delete-product-image',
+		array(
+			'label'       => __( 'Delete Product Image', 'extrachill-shop' ),
+			'description' => __( 'Remove a single image from a product. Products must keep at least one image.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'            => array(
+						'type'        => 'integer',
+						'description' => 'Product ID.',
+					),
+					'attachment_id' => array(
+						'type'        => 'integer',
+						'description' => 'Attachment ID of the image to delete.',
+					),
+				),
+				'required' => array( 'id', 'attachment_id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'     => array( 'type' => 'integer' ),
+					'images' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'object' ),
+					),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_delete_product_image',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				if ( current_user_can( 'manage_options' ) ) {
+					return true;
+				}
+				$product_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+				$product_post = get_post( $product_id );
+				if ( ! $product_post || 'product' !== $product_post->post_type ) {
+					return new WP_Error( 'product_not_found', 'Product not found.', array( 'status' => 404 ) );
+				}
+				$artist_id = (int) get_post_meta( $product_id, '_artist_profile_id', true );
+				if ( ! $artist_id ) {
+					return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this product.', array( 'status' => 403 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this product.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return false;
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => true,
+					'destructive' => true,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Delete a single image from a product.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_delete_product_image( array $input ): array|WP_Error {
+	$product_id    = (int) ( $input['id'] ?? 0 );
+	$attachment_id = (int) ( $input['attachment_id'] ?? 0 );
+
+	$product_post = get_post( $product_id );
+	if ( ! $product_post || 'product' !== $product_post->post_type ) {
+		return new WP_Error( 'product_not_found', 'Product not found.', array( 'status' => 404 ) );
+	}
+
+	// Get current ordered image IDs.
+	$ordered_ids = extrachill_shop_ability_delete_image_get_ordered_ids( $product_id );
+	if ( ! in_array( $attachment_id, $ordered_ids, true ) ) {
+		return new WP_Error( 'image_not_found', 'Image not found.', array( 'status' => 404 ) );
+	}
+
+	if ( count( $ordered_ids ) <= 1 ) {
+		return new WP_Error(
+			'cannot_delete_last_image',
+			'You must keep at least one image on a product.',
+			array( 'status' => 400 )
+		);
+	}
+
+	$attachment = get_post( $attachment_id );
+	if ( ! $attachment || 'attachment' !== $attachment->post_type || (int) $attachment->post_parent !== $product_id ) {
+		return new WP_Error( 'image_not_found', 'Image not found.', array( 'status' => 404 ) );
+	}
+
+	// Remove from ordered list.
+	$remaining = array_values( array_filter( $ordered_ids, static function ( int $id ) use ( $attachment_id ): bool {
+		return $id !== $attachment_id;
+	} ) );
+
+	// Update featured + gallery.
+	$featured_id = array_shift( $remaining );
+	set_post_thumbnail( $product_id, $featured_id );
+
+	if ( ! empty( $remaining ) ) {
+		update_post_meta( $product_id, '_product_image_gallery', implode( ',', $remaining ) );
+	} else {
+		delete_post_meta( $product_id, '_product_image_gallery' );
+	}
+
+	// Permanently delete the attachment.
+	$deleted = wp_delete_attachment( $attachment_id, true );
+	if ( ! $deleted ) {
+		return new WP_Error( 'delete_failed', 'Failed to delete attachment.', array( 'status' => 500 ) );
+	}
+
+	if ( function_exists( 'extrachill_shop_ability_build_product_response' ) ) {
+		return extrachill_shop_ability_build_product_response( $product_id );
+	}
+
+	return array( 'deleted' => true, 'product_id' => $product_id );
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Get ordered product image attachment IDs.
+ *
+ * @param int $product_id Product ID.
+ * @return int[]
+ */
+function extrachill_shop_ability_delete_image_get_ordered_ids( int $product_id ): array {
+	$featured_id = (int) get_post_thumbnail_id( $product_id );
+	$ids         = array();
+
+	if ( $featured_id ) {
+		$ids[] = $featured_id;
+	}
+
+	$gallery_raw = (string) get_post_meta( $product_id, '_product_image_gallery', true );
+	if ( $gallery_raw ) {
+		$gallery_ids = array_values( array_filter( array_map( 'absint', explode( ',', $gallery_raw ) ) ) );
+		$ids         = array_merge( $ids, $gallery_ids );
+	}
+
+	return array_values( array_unique( $ids ) );
+}

--- a/inc/abilities/shop-delete-product.php
+++ b/inc/abilities/shop-delete-product.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-delete-product
+ *
+ * Delete (trash) a WooCommerce product.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_delete_product_ability' );
+
+/**
+ * Register the shop-delete-product ability.
+ */
+function extrachill_shop_register_delete_product_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-delete-product',
+		array(
+			'label'       => __( 'Delete Shop Product', 'extrachill-shop' ),
+			'description' => __( 'Move a WooCommerce product to the trash.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id' => array(
+						'type'        => 'integer',
+						'description' => 'Product ID.',
+					),
+				),
+				'required' => array( 'id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'deleted'    => array( 'type' => 'boolean' ),
+					'product_id' => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_delete_product',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				if ( current_user_can( 'manage_options' ) ) {
+					return true;
+				}
+				$product_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+				$product_post = get_post( $product_id );
+				if ( ! $product_post || 'product' !== $product_post->post_type ) {
+					return new WP_Error( 'product_not_found', 'Product not found.', array( 'status' => 404 ) );
+				}
+				$artist_id = (int) get_post_meta( $product_id, '_artist_profile_id', true );
+				if ( ! $artist_id ) {
+					return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this product.', array( 'status' => 403 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this product.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return false;
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => false,
+					'destructive' => true,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Delete (trash) a product.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_delete_product( array $input ): array|WP_Error {
+	$product_id = (int) ( $input['id'] ?? 0 );
+
+	$product_post = get_post( $product_id );
+	if ( ! $product_post || 'product' !== $product_post->post_type ) {
+		return new WP_Error( 'product_not_found', 'Product not found.', array( 'status' => 404 ) );
+	}
+
+	$result = wp_trash_post( $product_id );
+
+	if ( ! $result ) {
+		return new WP_Error( 'delete_failed', 'Failed to delete product.', array( 'status' => 500 ) );
+	}
+
+	return array(
+		'deleted'    => true,
+		'product_id' => $product_id,
+	);
+}

--- a/inc/abilities/shop-update-product.php
+++ b/inc/abilities/shop-update-product.php
@@ -1,0 +1,296 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/shop-update-product
+ *
+ * Update an existing WooCommerce product.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillShop
+ * @since   0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_shop_register_update_product_ability' );
+
+/**
+ * Register the shop-update-product ability.
+ */
+function extrachill_shop_register_update_product_ability(): void {
+
+	wp_register_ability(
+		'extrachill/shop-update-product',
+		array(
+			'label'       => __( 'Update Shop Product', 'extrachill-shop' ),
+			'description' => __( 'Update an existing WooCommerce product — name, pricing, stock, status, images, sizes, and shipping.', 'extrachill-shop' ),
+			'category'    => 'extrachill-shop',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'             => array(
+						'type'        => 'integer',
+						'description' => 'Product ID.',
+					),
+					'artist_id'      => array(
+						'type'        => 'integer',
+						'description' => 'Reassign to a different artist profile ID.',
+					),
+					'name'           => array(
+						'type'        => 'string',
+						'description' => 'Product name.',
+					),
+					'price'          => array(
+						'type'        => 'number',
+						'description' => 'Regular price.',
+					),
+					'sale_price'     => array(
+						'type'        => 'number',
+						'description' => 'Sale price (set to 0 or null to clear).',
+					),
+					'description'    => array(
+						'type'        => 'string',
+						'description' => 'Product description.',
+					),
+					'manage_stock'   => array(
+						'type'        => 'boolean',
+						'description' => 'Whether to manage stock.',
+					),
+					'stock_quantity' => array(
+						'type'        => 'integer',
+						'description' => 'Stock quantity.',
+					),
+					'status'         => array(
+						'type'        => 'string',
+						'enum'        => array( 'draft', 'publish' ),
+						'description' => 'Product status.',
+					),
+					'image_id'       => array(
+						'type'        => 'integer',
+						'description' => 'Featured image attachment ID (0 to clear).',
+					),
+					'image_ids'      => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'integer' ),
+						'description' => 'Reorder images — first becomes featured, rest become gallery.',
+					),
+					'gallery_ids'    => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'integer' ),
+						'description' => 'Gallery image attachment IDs.',
+					),
+					'sizes'          => array(
+						'type'        => 'array',
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'name'  => array( 'type' => 'string' ),
+								'stock' => array( 'type' => 'integer' ),
+							),
+						),
+						'description' => 'Size variations with stock (empty array converts to simple product).',
+					),
+					'ships_free'     => array(
+						'type'        => 'boolean',
+						'description' => 'Whether the product ships free.',
+					),
+				),
+				'required' => array( 'id' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'     => array( 'type' => 'integer' ),
+					'name'   => array( 'type' => 'string' ),
+					'price'  => array( 'type' => 'string' ),
+					'status' => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_shop_ability_update_product',
+			'permission_callback' => static function ( array $input ): bool|WP_Error {
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error( 'rest_forbidden', 'You must be logged in.', array( 'status' => 401 ) );
+				}
+				if ( current_user_can( 'manage_options' ) ) {
+					return true;
+				}
+				$product_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+				$product_post = get_post( $product_id );
+				if ( ! $product_post || 'product' !== $product_post->post_type ) {
+					return new WP_Error( 'product_not_found', 'Product not found.', array( 'status' => 404 ) );
+				}
+				$artist_id = (int) get_post_meta( $product_id, '_artist_profile_id', true );
+				if ( ! $artist_id ) {
+					return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this product.', array( 'status' => 403 ) );
+				}
+				if ( function_exists( 'extrachill_api_shop_user_can_manage_artist' ) ) {
+					if ( ! extrachill_api_shop_user_can_manage_artist( $artist_id ) ) {
+						return new WP_Error( 'rest_forbidden', 'You do not have permission to manage this product.', array( 'status' => 403 ) );
+					}
+					return true;
+				}
+				if ( function_exists( 'ec_can_manage_artist' ) ) {
+					return ec_can_manage_artist( get_current_user_id(), $artist_id );
+				}
+				return false;
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Update a product.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_shop_ability_update_product( array $input ): array|WP_Error {
+	$product_id = (int) ( $input['id'] ?? 0 );
+
+	$product_post = get_post( $product_id );
+	if ( ! $product_post || 'product' !== $product_post->post_type ) {
+		return new WP_Error( 'product_not_found', 'Product not found.', array( 'status' => 404 ) );
+	}
+
+	// Name.
+	$name = $input['name'] ?? null;
+	if ( $name !== null ) {
+		wp_update_post( array(
+			'ID'         => $product_id,
+			'post_title' => sanitize_text_field( (string) $name ),
+		) );
+	}
+
+	// Description.
+	$description = $input['description'] ?? null;
+	if ( $description !== null ) {
+		wp_update_post( array(
+			'ID'           => $product_id,
+			'post_content' => wp_kses_post( wp_unslash( (string) $description ) ),
+		) );
+	}
+
+	// Price.
+	$price = $input['price'] ?? null;
+	if ( $price !== null && is_numeric( $price ) && (float) $price > 0 ) {
+		update_post_meta( $product_id, '_regular_price', (string) $price );
+		update_post_meta( $product_id, '_price', (string) $price );
+	}
+
+	// Image reorder (image_ids).
+	$image_ids = $input['image_ids'] ?? null;
+	if ( $image_ids !== null && function_exists( 'extrachill_api_shop_products_set_image_order' ) ) {
+		$reorder_result = extrachill_api_shop_products_set_image_order( $product_id, array_map( 'absint', (array) $image_ids ) );
+		if ( is_wp_error( $reorder_result ) ) {
+			return $reorder_result;
+		}
+	}
+
+	// Sale price.
+	$sale_price = $input['sale_price'] ?? null;
+	if ( $sale_price !== null ) {
+		$current_regular = (float) get_post_meta( $product_id, '_regular_price', true );
+		if ( is_numeric( $sale_price ) && (float) $sale_price > 0 && (float) $sale_price < $current_regular ) {
+			update_post_meta( $product_id, '_sale_price', (string) $sale_price );
+			update_post_meta( $product_id, '_price', (string) $sale_price );
+		} else {
+			delete_post_meta( $product_id, '_sale_price' );
+			update_post_meta( $product_id, '_price', (string) $current_regular );
+		}
+	}
+
+	// Stock management.
+	$manage_stock = $input['manage_stock'] ?? null;
+	if ( $manage_stock !== null ) {
+		update_post_meta( $product_id, '_manage_stock', $manage_stock ? 'yes' : 'no' );
+		if ( $manage_stock ) {
+			$stock_quantity = $input['stock_quantity'] ?? null;
+			if ( $stock_quantity !== null ) {
+				update_post_meta( $product_id, '_stock', (string) absint( (int) $stock_quantity ) );
+			}
+		} else {
+			delete_post_meta( $product_id, '_stock' );
+		}
+	}
+
+	// Featured image.
+	$image_id = $input['image_id'] ?? null;
+	if ( $image_id !== null ) {
+		if ( (int) $image_id > 0 ) {
+			set_post_thumbnail( $product_id, absint( (int) $image_id ) );
+		} else {
+			delete_post_thumbnail( $product_id );
+		}
+	}
+
+	// Gallery.
+	$gallery_ids = $input['gallery_ids'] ?? null;
+	if ( $gallery_ids !== null ) {
+		if ( is_array( $gallery_ids ) && ! empty( $gallery_ids ) ) {
+			$gallery_ids = array_map( 'absint', $gallery_ids );
+			$gallery_ids = array_filter( $gallery_ids );
+			$gallery_ids = array_slice( $gallery_ids, 0, 4 );
+			update_post_meta( $product_id, '_product_image_gallery', implode( ',', $gallery_ids ) );
+		} else {
+			delete_post_meta( $product_id, '_product_image_gallery' );
+		}
+	}
+
+	// Artist reassignment.
+	$artist_id = $input['artist_id'] ?? null;
+	if ( $artist_id !== null ) {
+		$artist_id = (int) $artist_id;
+		$can_manage = function_exists( 'extrachill_api_shop_user_can_manage_artist' )
+			? extrachill_api_shop_user_can_manage_artist( $artist_id )
+			: current_user_can( 'manage_options' );
+		if ( $can_manage ) {
+			update_post_meta( $product_id, '_artist_profile_id', $artist_id );
+			if ( function_exists( 'extrachill_api_shop_sync_artist_taxonomy' ) ) {
+				extrachill_api_shop_sync_artist_taxonomy( $product_id, $artist_id );
+			}
+		}
+	}
+
+	// Sizes / variations.
+	$sizes = $input['sizes'] ?? null;
+	if ( $sizes !== null && function_exists( 'extrachill_api_shop_setup_product_variations' ) ) {
+		$current_price      = get_post_meta( $product_id, '_regular_price', true );
+		$current_sale_price = get_post_meta( $product_id, '_sale_price', true );
+		$variation_result   = extrachill_api_shop_setup_product_variations( $product_id, (array) $sizes, $current_price, $current_sale_price );
+		if ( is_wp_error( $variation_result ) ) {
+			return $variation_result;
+		}
+	}
+
+	// Status.
+	$status = $input['status'] ?? null;
+	if ( $status !== null && function_exists( 'extrachill_api_shop_products_set_status' ) ) {
+		$status_result = extrachill_api_shop_products_set_status( $product_id, (string) $status );
+		if ( is_wp_error( $status_result ) ) {
+			return $status_result;
+		}
+	}
+
+	// Ships free.
+	$ships_free = $input['ships_free'] ?? null;
+	if ( $ships_free !== null ) {
+		update_post_meta( $product_id, '_ships_free', $ships_free ? '1' : '0' );
+	}
+
+	if ( function_exists( 'extrachill_shop_ability_build_product_response' ) ) {
+		return extrachill_shop_ability_build_product_response( $product_id );
+	}
+
+	return array( 'id' => $product_id );
+}


### PR DESCRIPTION
## Summary

- Registers **5 new shop-domain abilities** that were missing after the initial batch:
  - `extrachill/shop-create-product` — create a new WooCommerce product for an artist
  - `extrachill/shop-update-product` — update an existing product (name, pricing, stock, status, images, sizes, shipping)
  - `extrachill/shop-delete-product` — move a product to the trash
  - `extrachill/shop-delete-product-image` — remove a single image from a product (keeps ≥1 image)
  - `extrachill/shop-create-shipping-label` — purchase a USPS shipping label via Shippo
- All 5 have `meta.show_in_rest: true` and canonical `execute_callback` / `permission_callback` matching the existing pattern
- Permission semantics match the original REST routes in `extrachill-api`
- `stripe-webhook` intentionally stays REST-only (webhook receiver, not ability-shaped)
- Bootstrap loader (`inc/abilities/register.php`) updated with `require_once` for each new file
- `php -l` passes on all 20 ability files

## Route coverage (after this PR)

Every REST handler in `orders.php`, `products.php`, `product-images.php`, `shipping-address.php`, `shipping-labels.php`, and `stripe-connect.php` now has a matching registered ability. Only `stripe-webhook.php` is excluded by design.