### PR TITLE
refactor: route shipping-label email through ec_send_email + branded template

### DIFF
--- a/inc/abilities/shop-create-shipping-label.php
+++ b/inc/abilities/shop-create-shipping-label.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Ability: extrachill/shop-create-shipping-label
  *
@@ -10,6 +9,8 @@ declare(strict_types=1);
  * @package ExtraChillShop
  * @since   0.7.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
@@ -23,10 +24,10 @@ function extrachill_shop_register_create_shipping_label_ability(): void {
 	wp_register_ability(
 		'extrachill/shop-create-shipping-label',
 		array(
-			'label'       => __( 'Purchase Shipping Label', 'extrachill-shop' ),
-			'description' => __( 'Purchase a USPS shipping label via Shippo for an artist\'s portion of an order. Automatically selects the cheapest rate, updates order status, and emails the label.', 'extrachill-shop' ),
-			'category'    => 'extrachill-shop',
-			'input_schema' => array(
+			'label'               => __( 'Purchase Shipping Label', 'extrachill-shop' ),
+			'description'         => __( 'Purchase a USPS shipping label via Shippo for an artist\'s portion of an order. Automatically selects the cheapest rate, updates order status, and emails the label.', 'extrachill-shop' ),
+			'category'            => 'extrachill-shop',
+			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
 					'order_id'  => array(
@@ -38,9 +39,9 @@ function extrachill_shop_register_create_shipping_label_ability(): void {
 						'description' => 'Artist profile ID.',
 					),
 				),
-				'required' => array( 'order_id', 'artist_id' ),
+				'required'   => array( 'order_id', 'artist_id' ),
 			),
-			'output_schema' => array(
+			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
 					'success'         => array( 'type' => 'boolean' ),
@@ -73,7 +74,7 @@ function extrachill_shop_register_create_shipping_label_ability(): void {
 				}
 				return current_user_can( 'manage_options' );
 			},
-			'meta' => array(
+			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
 					'readonly'    => false,
@@ -123,7 +124,7 @@ function extrachill_shop_ability_create_shipping_label( array $input ): array|WP
 		return new WP_Error( 'order_not_found', 'Order not found.', array( 'status' => 404 ) );
 	}
 
-	$payouts = $order->get_meta( '_artist_payouts' ) ?: array();
+	$payouts = $order->get_meta( '_artist_payouts' ) ? $order->get_meta( '_artist_payouts' ) : array();
 	if ( ! isset( $payouts[ $artist_id ] ) ) {
 		return new WP_Error( 'invalid_artist', 'This order does not contain products from your artist.', array( 'status' => 400 ) );
 	}
@@ -143,8 +144,8 @@ function extrachill_shop_ability_create_shipping_label( array $input ): array|WP
 	// Return existing label if already purchased.
 	$existing_label = $order->get_meta( '_artist_label_' . $artist_id );
 	if ( ! empty( $existing_label ) ) {
-		$tracking   = $order->get_meta( '_artist_tracking_' . $artist_id ) ?: '';
-		$label_data = $order->get_meta( '_artist_label_data_' . $artist_id ) ?: array();
+		$tracking   = $order->get_meta( '_artist_tracking_' . $artist_id ) ? $order->get_meta( '_artist_tracking_' . $artist_id ) : '';
+		$label_data = $order->get_meta( '_artist_label_data_' . $artist_id ) ? $order->get_meta( '_artist_label_data_' . $artist_id ) : array();
 
 		return array(
 			'success'         => true,

--- a/inc/abilities/shop-create-shipping-label.php
+++ b/inc/abilities/shop-create-shipping-label.php
@@ -209,12 +209,16 @@ function extrachill_shop_ability_create_shipping_label( array $input ): array|WP
 	) );
 	$order->save();
 
-	// Send email notification.
+	// Send email notification via the centralized ec_send_email() pipeline
+	// so the dispatch routes through `extrachill/branded` + the
+	// SMTP-configured site. Soft-fails when the helper is unavailable
+	// (foundation PRs in extrachill-multisite / data-machine not yet
+	// merged) — the label purchase itself must still succeed.
 	$user       = get_userdata( $user_id );
 	$user_email = $user ? $user->user_email : '';
 
-	if ( $user_email && function_exists( 'extrachill_api_send_label_email' ) ) {
-		extrachill_api_send_label_email(
+	if ( $user_email && function_exists( 'ec_send_email' ) ) {
+		extrachill_shop_send_shipping_label_email(
 			$user_email,
 			$order,
 			$artist_id,
@@ -234,4 +238,120 @@ function extrachill_shop_ability_create_shipping_label( array $input ): array|WP
 		'service'         => $label_result['service'],
 		'cost'            => $label_result['cost'],
 	);
+}
+
+/**
+ * Send a branded shipping-label-ready email to the artist who purchased the label.
+ *
+ * Routes through `ec_send_email()` so the dispatch picks up the EC
+ * `extrachill/branded` template + `mail_site_id` SMTP routing. Builds
+ * the order-specific HTML body (tracking, ship-to address, line items,
+ * shop manager CTA) and hands it to the template as `body_html`.
+ *
+ * Caller MUST guard `function_exists( 'ec_send_email' )` before invoking
+ * this — when the foundation helper is missing we want the label purchase
+ * to still succeed without delivering an email.
+ *
+ * @param string   $to_email    Recipient email.
+ * @param WC_Order $order       WooCommerce order.
+ * @param int      $artist_id   Artist profile ID.
+ * @param array    $label_data  Label data from Shippo.
+ * @param array    $payout_data Artist payout data from order.
+ * @return void
+ */
+function extrachill_shop_send_shipping_label_email( $to_email, $order, $artist_id, $label_data, $payout_data ) {
+	$order_number  = $order->get_order_number();
+	$subject       = sprintf( 'Shipping Label Ready - Order #%s', $order_number );
+	$customer_name = trim( $order->get_billing_first_name() . ' ' . $order->get_billing_last_name() );
+
+	$items_html = '';
+	if ( ! empty( $payout_data['items'] ) && is_array( $payout_data['items'] ) ) {
+		$rows = array();
+		foreach ( $payout_data['items'] as $item ) {
+			$product_id = isset( $item['product_id'] ) ? (int) $item['product_id'] : 0;
+			$product    = $product_id && function_exists( 'wc_get_product' ) ? wc_get_product( $product_id ) : null;
+			$name       = $product ? $product->get_name() : 'Product';
+			$qty        = isset( $item['quantity'] ) ? (int) $item['quantity'] : 1;
+			$rows[]     = sprintf(
+				'<li style="margin:0 0 4px 0;">%s <span style="color:#666;">(x%d)</span></li>',
+				esc_html( $name ),
+				$qty
+			);
+		}
+		if ( ! empty( $rows ) ) {
+			$items_html = '<ul style="margin:0 0 16px 20px;padding:0;">' . implode( '', $rows ) . '</ul>';
+		}
+	}
+
+	$shipping = $order->get_address( 'shipping' );
+	$billing  = $order->get_address( 'billing' );
+	$address  = ! empty( $shipping['address_1'] ) ? $shipping : $billing;
+
+	$address_lines = array_filter( array(
+		$customer_name,
+		isset( $address['address_1'] ) ? $address['address_1'] : '',
+		isset( $address['address_2'] ) ? $address['address_2'] : '',
+		trim( sprintf(
+			'%s, %s %s',
+			isset( $address['city'] ) ? $address['city'] : '',
+			isset( $address['state'] ) ? $address['state'] : '',
+			isset( $address['postcode'] ) ? $address['postcode'] : ''
+		), ', ' ),
+	), static function ( $line ) {
+		return '' !== trim( (string) $line );
+	} );
+
+	$address_html = '<p style="margin:0 0 16px 0;line-height:1.5;">' . implode( '<br>', array_map( 'esc_html', $address_lines ) ) . '</p>';
+
+	$shop_manager_url = home_url( '/shop-manager/' );
+	$tracking_number  = isset( $label_data['tracking_number'] ) ? (string) $label_data['tracking_number'] : '';
+	$label_url        = isset( $label_data['label_url'] ) ? (string) $label_data['label_url'] : '';
+	$carrier          = isset( $label_data['carrier'] ) ? (string) $label_data['carrier'] : '';
+	$service          = isset( $label_data['service'] ) ? (string) $label_data['service'] : '';
+
+	$body_html  = sprintf(
+		'<p style="margin:0 0 16px 0;font-size:16px;line-height:1.6;">Your shipping label for <strong>Order #%s</strong> is ready.</p>',
+		esc_html( $order_number )
+	);
+	$body_html .= '<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 16px 0;font-size:15px;line-height:1.6;">';
+	$body_html .= sprintf(
+		'<tr><td style="padding:4px 16px 4px 0;color:#666;">Tracking</td><td style="padding:4px 0;"><strong>%s</strong></td></tr>',
+		esc_html( $tracking_number )
+	);
+	$body_html .= sprintf(
+		'<tr><td style="padding:4px 16px 4px 0;color:#666;">Carrier</td><td style="padding:4px 0;">%s %s</td></tr>',
+		esc_html( $carrier ),
+		esc_html( $service )
+	);
+	$body_html .= '</table>';
+
+	if ( '' !== $label_url ) {
+		$body_html .= sprintf(
+			'<p style="margin:0 0 24px 0;"><a href="%s" style="color:#0073aa;text-decoration:underline;">Download / Print Label (PDF)</a></p>',
+			esc_url( $label_url )
+		);
+	}
+
+	$body_html .= '<h3 style="margin:24px 0 8px 0;font-size:16px;">Ship To</h3>';
+	$body_html .= $address_html;
+
+	if ( '' !== $items_html ) {
+		$body_html .= '<h3 style="margin:24px 0 8px 0;font-size:16px;">Items</h3>';
+		$body_html .= $items_html;
+	}
+
+	$preheader = sprintf( 'Tracking %s — label ready to print.', $tracking_number );
+
+	ec_send_email( array(
+		'to'      => $to_email,
+		'subject' => $subject,
+		'context' => array(
+			'subject_html'   => esc_html( $subject ),
+			'recipient_name' => $customer_name,
+			'body_html'      => $body_html,
+			'cta_url'        => $shop_manager_url,
+			'cta_label'      => 'Open Shop Manager',
+			'preheader'      => $preheader,
+		),
+	) );
 }


### PR DESCRIPTION
## Summary

Companion to **Extra-Chill/extrachill-api#51**. Moves the shipping-label email side-effect off the upside-down callback into `extrachill_api_send_label_email()` and onto the centralized `ec_send_email()` pipeline with the `extrachill/branded` template.

## Why

The `extrachill/shop-create-shipping-label` ability previously called back into `extrachill_api_send_label_email()` over in **extrachill-api**. That is an inverted dependency — the ability layer (logic + side-effects) reached upward into the REST wrapper layer to dispatch its own email. Per `MEMORY.md`:

> `extrachill-api` is a REST wrapper ONLY: abilities own logic/writes; REST handlers must be thin calls to `wp_get_ability()->execute()`.

So both the email send and the order/Shippo side-effects belong in this ability. They already do, except the email was outsourced. This PR pulls it back home, and at the same time migrates it off raw `wp_mail()` onto `ec_send_email()`.

## What changes

- Replace the `extrachill_api_send_label_email()` callback with an inline `extrachill_shop_send_shipping_label_email()` helper inside `inc/abilities/shop-create-shipping-label.php`.
- Build the order-specific HTML body (tracking, carrier, ship-to address, items list, label download link) and pass it as `context.body_html` to `ec_send_email()` using the `extrachill/branded` template.
- Use `cta_url` / `cta_label` for the Shop Manager link.
- Guard `function_exists( 'ec_send_email' )` so the label purchase still succeeds when the foundation helper is not yet active (foundation PRs not merged).
- SMTP routing / `switch_to_blog` is delegated to the underlying `datamachine/send-email` ability via the `mail_site_id` default applied by `ec_send_email()` — this plugin does not wrap the call in its own `switch_to_blog`.

## Dependencies

- **Extra-Chill/data-machine#2067** — `template`, `context`, `mail_site_id` inputs on `datamachine/send-email`
- **Extra-Chill/extrachill-multisite#27** — `ec_send_email()` helper + `extrachill/branded` template

Opened as **DRAFT** until both foundation PRs merge.

## Companion PR

- **extrachill-api**: collapses the POST `/shop/shipping-labels` handler to a thin ability call and deletes `extrachill_api_send_label_email()` — see Extra-Chill/extrachill-api#51

## Smoke note

Smoke test on staging post-merge of foundations:
1. As an artist owner, hit `POST /wp-json/extrachill/v1/shop/shipping-labels` for an order that contains shippable items.
2. Confirm: label is purchased, order status → completed, tracking + label URL saved on order meta.
3. Confirm: branded email arrives at the artist's account email with tracking, carrier, ship-to address, items, and Open Shop Manager CTA, rendered with the EC chrome.
4. Confirm: when `ec_send_email` is missing (foundation not active), label purchase still succeeds and the ability returns the same success payload — only the email is skipped.

## Acceptance

- [x] Email dispatch lives in the ability, not in the REST wrapper
- [x] No raw `wp_mail()` introduced
- [x] Branded template used via `context.body_html`
- [x] SMTP-site switching delegated to `ec_send_email` (no local `switch_to_blog`)
- [x] Guarded against missing `ec_send_email` for graceful degradation pre-foundation

Refs Extra-Chill/extrachill-api#51