### PR TITLE
refactor: replace hardcoded extrachill.com domain with ec_get_site_url

### DIFF
--- a/inc/products/priority-boost.php
+++ b/inc/products/priority-boost.php
@@ -47,8 +47,12 @@ function extrachill_shop_get_posted_event_url() {
 function extrachill_shop_parse_event_url( $url ) {
 	$parsed = wp_parse_url( $url );
 
-	if ( empty( $parsed['host'] ) || 'events.extrachill.com' !== $parsed['host'] ) {
-		return new WP_Error( 'invalid_domain', 'URL must be from events.extrachill.com' );
+	$events_host = function_exists( 'ec_get_site_url' )
+		? wp_parse_url( ec_get_site_url( 'events' ), PHP_URL_HOST )
+		: '';
+
+	if ( empty( $parsed['host'] ) || empty( $events_host ) || $events_host !== $parsed['host'] ) {
+		return new WP_Error( 'invalid_domain', 'URL must be from the events site.' );
 	}
 
 	if ( empty( $parsed['path'] ) || ! preg_match( '#^/event/([^/]+)/?$#', $parsed['path'], $matches ) ) {


### PR DESCRIPTION
## Summary
Replaces the hardcoded `'events.extrachill.com'` host check in the priority-boost event URL validator with a host derived from `ec_get_site_url( 'events' )` via `wp_parse_url( ..., PHP_URL_HOST )`.

Line 64 already used `ec_get_blog_id( 'events' )`, so the host check is now consistent with the domain map. On staging/dev clones the `ec_site_url_override` filter rewrites domains; the hardcoded host check rejected valid clone URLs.

## Changes
- `inc/products/priority-boost.php:48-52` — derive the events host from the domain map; error message no longer hardcodes the production domain

## Verification
- Site key `events` → blog ID 7 → `events.extrachill.com` (matches the replaced literal); no behavior change on production, clones now resolve correctly.

refs Extra-Chill/extrachill-multisite#36