### PR TITLE
refactor: parameterize product provisioning (closes #12)

### DIFF
--- a/extrachill-shop.php
+++ b/extrachill-shop.php
@@ -52,6 +52,7 @@ class ExtraChillShop {
 
 	private function load_includes() {
 		// Product customizations
+		require_once EXTRACHILL_SHOP_PLUGIN_DIR . 'inc/products/product-provisioning.php';
 		require_once EXTRACHILL_SHOP_PLUGIN_DIR . 'inc/products/lifetime-membership-product.php';
 		require_once EXTRACHILL_SHOP_PLUGIN_DIR . 'inc/products/lifetime-membership.php';
 		require_once EXTRACHILL_SHOP_PLUGIN_DIR . 'inc/products/priority-boost-product.php';

--- a/inc/products/lifetime-membership-product.php
+++ b/inc/products/lifetime-membership-product.php
@@ -5,6 +5,9 @@
  * Ensures the Lifetime Extra Chill Membership product always exists on the shop site.
  * Uses a fixed SKU as the canonical identifier and caches the product ID in an option.
  *
+ * Thin config caller — the shared provisioning logic lives in
+ * inc/products/product-provisioning.php.
+ *
  * @package ExtraChillShop
  * @since 0.2.0
  */
@@ -29,88 +32,34 @@ function extrachill_shop_get_lifetime_membership_product_sync_transient_key() {
 	return 'extrachill_shop_lifetime_membership_product_sync_daily';
 }
 
+/**
+ * Provisioning config for the lifetime membership product.
+ *
+ * @return array
+ */
+function extrachill_shop_get_lifetime_membership_product_config() {
+	return array(
+		'sku'                   => extrachill_shop_get_lifetime_membership_sku(),
+		'name'                  => 'Lifetime Extra Chill Membership',
+		'price'                 => '20',
+		'sold_individually'     => true,
+		'short_description'      => 'Support independent music journalism and enjoy an ad-free experience across the entire Extra Chill network. One-time payment, lifetime status.',
+		'option_key'            => extrachill_shop_get_lifetime_membership_product_option_key(),
+		'sync_flag_key'         => extrachill_shop_get_lifetime_membership_product_sync_flag_key(),
+		'sync_transient_key'    => extrachill_shop_get_lifetime_membership_product_sync_transient_key(),
+		'invalid_product_error' => 'Lifetime membership product ID is invalid.',
+		'save_failed_error'     => 'Failed to save lifetime membership product.',
+	);
+}
+
 function extrachill_shop_get_lifetime_membership_product_id() {
-	if ( ! function_exists( 'wc_get_product' ) ) {
-		return 0;
-	}
-
-	$option_key = extrachill_shop_get_lifetime_membership_product_option_key();
-	$stored_id  = absint( get_option( $option_key ) );
-	$sku        = extrachill_shop_get_lifetime_membership_sku();
-
-	if ( $stored_id ) {
-		$product = wc_get_product( $stored_id );
-		if ( $product && $product->get_sku() === $sku ) {
-			return $stored_id;
-		}
-	}
-
-	$product_id = absint( wc_get_product_id_by_sku( $sku ) );
-	if ( $product_id ) {
-		update_option( $option_key, $product_id );
-		return $product_id;
-	}
-
-	return 0;
+	return extrachill_shop_provision_get_product_id( extrachill_shop_get_lifetime_membership_product_config() );
 }
 
 function extrachill_shop_maybe_sync_lifetime_membership_product() {
-	if ( ! function_exists( 'wc_get_product' ) || ! class_exists( 'WC_Product_Simple' ) ) {
-		return;
-	}
-
-	$sync_flag_key = extrachill_shop_get_lifetime_membership_product_sync_flag_key();
-	$needs_sync    = (bool) get_option( $sync_flag_key );
-
-	if ( $needs_sync ) {
-		extrachill_shop_ensure_lifetime_membership_product();
-		delete_option( $sync_flag_key );
-		delete_transient( extrachill_shop_get_lifetime_membership_product_sync_transient_key() );
-		return;
-	}
-
-	if ( get_transient( extrachill_shop_get_lifetime_membership_product_sync_transient_key() ) ) {
-		return;
-	}
-
-	extrachill_shop_ensure_lifetime_membership_product();
-	set_transient( extrachill_shop_get_lifetime_membership_product_sync_transient_key(), 1, DAY_IN_SECONDS );
+	extrachill_shop_provision_maybe_sync_product( extrachill_shop_get_lifetime_membership_product_config() );
 }
 
 function extrachill_shop_ensure_lifetime_membership_product() {
-	$sku        = extrachill_shop_get_lifetime_membership_sku();
-	$product_id = absint( wc_get_product_id_by_sku( $sku ) );
-
-	if ( $product_id ) {
-		$product = wc_get_product( $product_id );
-		if ( ! $product ) {
-			return new WP_Error( 'invalid_product', 'Lifetime membership product ID is invalid.' );
-		}
-	} else {
-		$product = new WC_Product_Simple();
-		$product->set_name( 'Lifetime Extra Chill Membership' );
-		$product->set_sku( $sku );
-	}
-
-	$product->set_status( 'publish' );
-	$product->set_catalog_visibility( 'visible' );
-	$product->set_virtual( true );
-	$product->set_sold_individually( true );
-	$product->set_regular_price( '20' );
-	$product->set_tax_status( 'none' );
-	$product->set_short_description( 'Support independent music journalism and enjoy an ad-free experience across the entire Extra Chill network. One-time payment, lifetime status.' );
-
-	$saved_product_id = absint( $product->save() );
-	if ( ! $saved_product_id ) {
-		return new WP_Error( 'save_failed', 'Failed to save lifetime membership product.' );
-	}
-
-	update_option( extrachill_shop_get_lifetime_membership_product_option_key(), $saved_product_id );
-
-	// Link product to platform artist for shop manager visibility.
-	if ( defined( 'EC_PLATFORM_ARTIST_ID' ) && function_exists( 'extrachill_shop_set_product_artist' ) ) {
-		extrachill_shop_set_product_artist( $saved_product_id, EC_PLATFORM_ARTIST_ID );
-	}
-
-	return $saved_product_id;
+	return extrachill_shop_provision_ensure_product( extrachill_shop_get_lifetime_membership_product_config() );
 }

--- a/inc/products/priority-boost-product.php
+++ b/inc/products/priority-boost-product.php
@@ -5,6 +5,9 @@
  * Ensures the Event Priority Boost product always exists on the shop site.
  * Uses a fixed SKU as the canonical identifier and caches the product ID in an option.
  *
+ * Thin config caller — the shared provisioning logic lives in
+ * inc/products/product-provisioning.php.
+ *
  * @package ExtraChillShop
  * @since 0.6.0
  */
@@ -29,87 +32,34 @@ function extrachill_shop_get_priority_boost_product_sync_transient_key() {
 	return 'extrachill_shop_priority_boost_product_sync_daily';
 }
 
+/**
+ * Provisioning config for the priority boost product.
+ *
+ * @return array
+ */
+function extrachill_shop_get_priority_boost_product_config() {
+	return array(
+		'sku'                   => extrachill_shop_get_priority_boost_sku(),
+		'name'                  => 'Event Priority Boost',
+		'price'                 => '5',
+		'sold_individually'     => false,
+		'short_description'      => 'Boost an event to appear first in the calendar for its date.',
+		'option_key'            => extrachill_shop_get_priority_boost_product_option_key(),
+		'sync_flag_key'         => extrachill_shop_get_priority_boost_product_sync_flag_key(),
+		'sync_transient_key'    => extrachill_shop_get_priority_boost_product_sync_transient_key(),
+		'invalid_product_error' => 'Priority boost product ID is invalid.',
+		'save_failed_error'     => 'Failed to save priority boost product.',
+	);
+}
+
 function extrachill_shop_get_priority_boost_product_id() {
-	if ( ! function_exists( 'wc_get_product' ) ) {
-		return 0;
-	}
-
-	$option_key = extrachill_shop_get_priority_boost_product_option_key();
-	$stored_id  = absint( get_option( $option_key ) );
-	$sku        = extrachill_shop_get_priority_boost_sku();
-
-	if ( $stored_id ) {
-		$product = wc_get_product( $stored_id );
-		if ( $product && $product->get_sku() === $sku ) {
-			return $stored_id;
-		}
-	}
-
-	$product_id = absint( wc_get_product_id_by_sku( $sku ) );
-	if ( $product_id ) {
-		update_option( $option_key, $product_id );
-		return $product_id;
-	}
-
-	return 0;
+	return extrachill_shop_provision_get_product_id( extrachill_shop_get_priority_boost_product_config() );
 }
 
 function extrachill_shop_maybe_sync_priority_boost_product() {
-	if ( ! function_exists( 'wc_get_product' ) || ! class_exists( 'WC_Product_Simple' ) ) {
-		return;
-	}
-
-	$sync_flag_key = extrachill_shop_get_priority_boost_product_sync_flag_key();
-	$needs_sync    = (bool) get_option( $sync_flag_key );
-
-	if ( $needs_sync ) {
-		extrachill_shop_ensure_priority_boost_product();
-		delete_option( $sync_flag_key );
-		delete_transient( extrachill_shop_get_priority_boost_product_sync_transient_key() );
-		return;
-	}
-
-	if ( get_transient( extrachill_shop_get_priority_boost_product_sync_transient_key() ) ) {
-		return;
-	}
-
-	extrachill_shop_ensure_priority_boost_product();
-	set_transient( extrachill_shop_get_priority_boost_product_sync_transient_key(), 1, DAY_IN_SECONDS );
+	extrachill_shop_provision_maybe_sync_product( extrachill_shop_get_priority_boost_product_config() );
 }
 
 function extrachill_shop_ensure_priority_boost_product() {
-	$sku        = extrachill_shop_get_priority_boost_sku();
-	$product_id = absint( wc_get_product_id_by_sku( $sku ) );
-
-	if ( $product_id ) {
-		$product = wc_get_product( $product_id );
-		if ( ! $product ) {
-			return new WP_Error( 'invalid_product', 'Priority boost product ID is invalid.' );
-		}
-	} else {
-		$product = new WC_Product_Simple();
-		$product->set_name( 'Event Priority Boost' );
-		$product->set_sku( $sku );
-	}
-
-	$product->set_status( 'publish' );
-	$product->set_catalog_visibility( 'visible' );
-	$product->set_virtual( true );
-	$product->set_sold_individually( false );
-	$product->set_regular_price( '5' );
-	$product->set_tax_status( 'none' );
-	$product->set_short_description( 'Boost an event to appear first in the calendar for its date.' );
-
-	$saved_product_id = absint( $product->save() );
-	if ( ! $saved_product_id ) {
-		return new WP_Error( 'save_failed', 'Failed to save priority boost product.' );
-	}
-
-	update_option( extrachill_shop_get_priority_boost_product_option_key(), $saved_product_id );
-
-	if ( defined( 'EC_PLATFORM_ARTIST_ID' ) && function_exists( 'extrachill_shop_set_product_artist' ) ) {
-		extrachill_shop_set_product_artist( $saved_product_id, EC_PLATFORM_ARTIST_ID );
-	}
-
-	return $saved_product_id;
+	return extrachill_shop_provision_ensure_product( extrachill_shop_get_priority_boost_product_config() );
 }

--- a/inc/products/product-provisioning.php
+++ b/inc/products/product-provisioning.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Shared Product Provisioning
+ *
+ * Generic, parameterized provisioner for shop products that are pinned to a
+ * fixed SKU and cached via an option. Both the lifetime-membership and
+ * priority-boost products delegate to these helpers with their own config.
+ *
+ * A config array has the following shape:
+ *   - sku                 (string) Canonical SKU identifier.
+ *   - name                (string) Product name (used on first creation).
+ *   - price               (string) Regular price.
+ *   - sold_individually   (bool)   Whether the product is sold individually.
+ *   - short_description    (string) Product short description.
+ *   - option_key          (string) Option storing the resolved product ID.
+ *   - sync_flag_key        (string) Option flagging an immediate sync.
+ *   - sync_transient_key   (string) Transient throttling the daily sync.
+ *   - invalid_product_error (string) Message for an invalid stored product ID.
+ *   - save_failed_error     (string) Message when the product fails to save.
+ *
+ * @package ExtraChillShop
+ * @since 0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolve the product ID for a given provisioning config.
+ *
+ * @param array $config Provisioning config.
+ * @return int Product ID, or 0 if WooCommerce is unavailable or the product
+ *             does not yet exist.
+ */
+function extrachill_shop_provision_get_product_id( array $config ) {
+	if ( ! function_exists( 'wc_get_product' ) ) {
+		return 0;
+	}
+
+	$option_key = $config['option_key'];
+	$stored_id  = absint( get_option( $option_key ) );
+	$sku        = $config['sku'];
+
+	if ( $stored_id ) {
+		$product = wc_get_product( $stored_id );
+		if ( $product && $product->get_sku() === $sku ) {
+			return $stored_id;
+		}
+	}
+
+	$product_id = absint( wc_get_product_id_by_sku( $sku ) );
+	if ( $product_id ) {
+		update_option( $option_key, $product_id );
+		return $product_id;
+	}
+
+	return 0;
+}
+
+/**
+ * Conditionally sync the product described by a config.
+ *
+ * Honors the immediate sync flag, then throttles to once per day via a
+ * transient.
+ *
+ * @param array $config Provisioning config.
+ * @return void
+ */
+function extrachill_shop_provision_maybe_sync_product( array $config ) {
+	if ( ! function_exists( 'wc_get_product' ) || ! class_exists( 'WC_Product_Simple' ) ) {
+		return;
+	}
+
+	$sync_flag_key      = $config['sync_flag_key'];
+	$sync_transient_key = $config['sync_transient_key'];
+	$needs_sync         = (bool) get_option( $sync_flag_key );
+
+	if ( $needs_sync ) {
+		extrachill_shop_provision_ensure_product( $config );
+		delete_option( $sync_flag_key );
+		delete_transient( $sync_transient_key );
+		return;
+	}
+
+	if ( get_transient( $sync_transient_key ) ) {
+		return;
+	}
+
+	extrachill_shop_provision_ensure_product( $config );
+	set_transient( $sync_transient_key, 1, DAY_IN_SECONDS );
+}
+
+/**
+ * Ensure the product described by a config exists and is up to date.
+ *
+ * @param array $config Provisioning config.
+ * @return int|WP_Error Saved product ID, or WP_Error on failure.
+ */
+function extrachill_shop_provision_ensure_product( array $config ) {
+	$sku        = $config['sku'];
+	$product_id = absint( wc_get_product_id_by_sku( $sku ) );
+
+	if ( $product_id ) {
+		$product = wc_get_product( $product_id );
+		if ( ! $product ) {
+			return new WP_Error( 'invalid_product', $config['invalid_product_error'] );
+		}
+	} else {
+		$product = new WC_Product_Simple();
+		$product->set_name( $config['name'] );
+		$product->set_sku( $sku );
+	}
+
+	$product->set_status( 'publish' );
+	$product->set_catalog_visibility( 'visible' );
+	$product->set_virtual( true );
+	$product->set_sold_individually( $config['sold_individually'] );
+	$product->set_regular_price( $config['price'] );
+	$product->set_tax_status( 'none' );
+	$product->set_short_description( $config['short_description'] );
+
+	$saved_product_id = absint( $product->save() );
+	if ( ! $saved_product_id ) {
+		return new WP_Error( 'save_failed', $config['save_failed_error'] );
+	}
+
+	update_option( $config['option_key'], $saved_product_id );
+
+	// Link product to platform artist for shop manager visibility.
+	if ( defined( 'EC_PLATFORM_ARTIST_ID' ) && function_exists( 'extrachill_shop_set_product_artist' ) ) {
+		extrachill_shop_set_product_artist( $saved_product_id, EC_PLATFORM_ARTIST_ID );
+	}
+
+	return $saved_product_id;
+}


### PR DESCRIPTION
## Summary

Collapses the line-for-line copy-paste fork between `inc/products/lifetime-membership-product.php` and `inc/products/priority-boost-product.php` into a single shared, config-driven provisioner. Closes #12.

## The shared provisioner

New `inc/products/product-provisioning.php` exposes three parameterized helpers that contain the previously duplicated logic:

- `extrachill_shop_provision_get_product_id( array $config )` — stored-ID + SKU resolution
- `extrachill_shop_provision_maybe_sync_product( array $config )` — sync-flag + daily-transient gated sync
- `extrachill_shop_provision_ensure_product( array $config )` — create/update + option cache + platform-artist link

A config array carries `sku / name / price / sold_individually / short_description / option_key / sync_flag_key / sync_transient_key / invalid_product_error / save_failed_error`.

## Preserved public API

Both product files are now thin config callers. **Every original public function name and signature is retained**, so all callers (`lifetime-membership.php`, `priority-boost.php`, and the external sync-flag writers in `extrachill-shop.php` and `extrachill-artist-platform`) are unaffected:

- `extrachill_shop_get_{lifetime_membership,priority_boost}_sku()`
- `extrachill_shop_get_{...}_product_option_key()`
- `extrachill_shop_get_{...}_product_sync_flag_key()`
- `extrachill_shop_get_{...}_product_sync_transient_key()`
- `extrachill_shop_get_{...}_product_id()`
- `extrachill_shop_maybe_sync_{...}_product()`
- `extrachill_shop_ensure_{...}_product()`

(Each file also gains a private `extrachill_shop_get_{...}_product_config()` helper that builds the config.)

## Identical config confirmation

| | Lifetime | Priority Boost |
|---|---|---|
| SKU | `ec-lifetime-membership` | `extrachill-event-priority-boost` |
| price | `20` | `5` |
| sold_individually | `true` | `false` |
| option key | `extrachill_shop_lifetime_membership_product_id` | `extrachill_shop_priority_boost_product_id` |
| sync flag key | `extrachill_shop_needs_lifetime_membership_product_sync` | `extrachill_shop_needs_priority_boost_product_sync` |
| sync transient key | `extrachill_shop_lifetime_membership_product_sync_daily` | `extrachill_shop_priority_boost_product_sync_daily` |

Descriptions, `WP_Error` messages, status/visibility/virtual/tax flags, and the `EC_PLATFORM_ARTIST_ID` linking all preserved exactly.

## Loader

`product-provisioning.php` is required in `extrachill-shop.php` before the two product files so the shared helpers are available.

## Verification

- `php -l` clean on all four touched files.
- All public function names/signatures confirmed unchanged via grep.