### PR TITLE
refactor: drop the last jQuery dependency (raffle admin script)

### DIFF
--- a/assets/css/raffle-admin.css
+++ b/assets/css/raffle-admin.css
@@ -6,11 +6,18 @@
  * @package ExtraChillShop
  */
 .raffle-max-tickets-field {
-    display: none;
+    display: block;
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 300ms ease, max-height 300ms ease, visibility 300ms ease;
 }
 
 .raffle-max-tickets-field.visible {
-    display: block;
+    max-height: 500px;
+    opacity: 1;
+    visibility: visible;
 }
 
 .raffle-max-tickets-field label {

--- a/assets/js/raffle-admin.js
+++ b/assets/js/raffle-admin.js
@@ -7,13 +7,13 @@
  * @package ExtraChillShop
  */
 
-(function($) {
+(function() {
     'use strict';
 
     function hasRaffleTag() {
-        const tagInputs = $('.tagchecklist span a');
+        const tagInputs = document.querySelectorAll('.tagchecklist span a');
         for (let i = 0; i < tagInputs.length; i++) {
-            const tagText = $(tagInputs[i]).text().toLowerCase().replace(/[^a-z0-9]/g, '');
+            const tagText = tagInputs[i].textContent.toLowerCase().replace(/[^a-z0-9]/g, '');
             if (tagText === 'raffle') {
                 return true;
             }
@@ -22,22 +22,21 @@
     }
 
     function toggleRaffleField() {
-        const $raffleField = $('.raffle-max-tickets-field');
+        const raffleFields = document.querySelectorAll('.raffle-max-tickets-field');
+        const visible = hasRaffleTag();
 
-        if (hasRaffleTag()) {
-            $raffleField.addClass('visible').fadeIn(300);
-        } else {
-            $raffleField.removeClass('visible').fadeOut(300);
+        for (let i = 0; i < raffleFields.length; i++) {
+            raffleFields[i].classList.toggle('visible', visible);
         }
     }
 
-    $(document).ready(function() {
+    document.addEventListener('DOMContentLoaded', function() {
         toggleRaffleField();
 
         const tagListContainer = document.querySelector('.tagchecklist');
 
         if (tagListContainer) {
-            const observer = new MutationObserver(function(mutations) {
+            const observer = new MutationObserver(function() {
                 toggleRaffleField();
             });
 
@@ -50,4 +49,4 @@
         setInterval(toggleRaffleField, 500);
     });
 
-})(jQuery);
+})();

--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -125,7 +125,7 @@ function extrachill_shop_enqueue_raffle_admin_assets( $hook ) {
 		wp_enqueue_script(
 			'extrachill-shop-raffle-admin',
 			EXTRACHILL_SHOP_PLUGIN_URL . 'assets/js/raffle-admin.js',
-			array( 'jquery' ),
+			array(),
 			filemtime( $js_file ),
 			true
 		);


### PR DESCRIPTION
## Summary

Closes #16.

`assets/js/raffle-admin.js` was the **only live jQuery-dependent script in the entire Extra Chill plugin/theme set**. It is now rewritten as vanilla JS, and the enqueue no longer declares `jquery` as a dependency. This removes the last jQuery dependency from the EC stack.

## JS: before / after

**Before** (jQuery IIFE):
```js
(function($) {
    'use strict';

    function hasRaffleTag() {
        const tagInputs = $('.tagchecklist span a');
        for (let i = 0; i < tagInputs.length; i++) {
            const tagText = $(tagInputs[i]).text().toLowerCase().replace(/[^a-z0-9]/g, '');
            if (tagText === 'raffle') { return true; }
        }
        return false;
    }

    function toggleRaffleField() {
        const $raffleField = $('.raffle-max-tickets-field');
        if (hasRaffleTag()) {
            $raffleField.addClass('visible').fadeIn(300);
        } else {
            $raffleField.removeClass('visible').fadeOut(300);
        }
    }

    $(document).ready(function() { ... });
})(jQuery);
```

**After** (vanilla, plain IIFE — no jQuery arg):
```js
(function() {
    'use strict';

    function hasRaffleTag() {
        const tagInputs = document.querySelectorAll('.tagchecklist span a');
        for (let i = 0; i < tagInputs.length; i++) {
            const tagText = tagInputs[i].textContent.toLowerCase().replace(/[^a-z0-9]/g, '');
            if (tagText === 'raffle') { return true; }
        }
        return false;
    }

    function toggleRaffleField() {
        const raffleFields = document.querySelectorAll('.raffle-max-tickets-field');
        const visible = hasRaffleTag();
        for (let i = 0; i < raffleFields.length; i++) {
            raffleFields[i].classList.toggle('visible', visible);
        }
    }

    document.addEventListener('DOMContentLoaded', function() { ... });
})();
```

Mapping:
- `$('.tagchecklist span a')` → `document.querySelectorAll('.tagchecklist span a')`
- `$(el).text()` → `el.textContent`
- `addClass/removeClass('visible')` + `.fadeIn(300)/.fadeOut(300)` → `classList.toggle('visible', visible)` (fade now handled by CSS)
- `$(document).ready(...)` → `document.addEventListener('DOMContentLoaded', ...)`

The `MutationObserver` + 500ms `setInterval` polling fallback and the exact `raffle` tag text-matching logic are preserved unchanged, so show/hide trigger behavior is identical.

## CSS: the fade is now a transition

`.fadeIn/.fadeOut` cannot be replicated by toggling `display` (not transitionable), so the field is now always laid out and faded via `opacity` / `max-height` / `visibility`, keyed off the existing `.visible` class:

```css
.raffle-max-tickets-field {
    display: block;
    overflow: hidden;
    max-height: 0;
    opacity: 0;
    visibility: hidden;
    transition: opacity 300ms ease, max-height 300ms ease, visibility 300ms ease;
}

.raffle-max-tickets-field.visible {
    max-height: 500px;
    opacity: 1;
    visibility: visible;
}
```

This matches the original 300ms fade duration. The field is collapsed (zero height, hidden, non-interactive) when not visible.

## Enqueue dependency change

`inc/core/assets.php:128`:
```diff
- array( 'jquery' ),
+ array(),
```

## Note

This removes the **last jQuery dependency in the entire Extra Chill plugin/theme set**.