### PR TITLE
fix: guard ability category registration against double-fire _doing_it_wrong notice

### DIFF
--- a/inc/abilities/register.php
+++ b/inc/abilities/register.php
@@ -18,6 +18,14 @@ add_action( 'wp_abilities_api_categories_init', 'extrachill_shop_register_abilit
  * Register shop ability category.
  */
 function extrachill_shop_register_ability_category(): void {
+	if ( ! function_exists( 'wp_register_ability_category' ) ) {
+		return;
+	}
+
+	if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'extrachill-shop' ) ) {
+		return;
+	}
+
 	wp_register_ability_category(
 		'extrachill-shop',
 		array(


### PR DESCRIPTION
## The notice

```
PHP Notice: Function WP_Ability_Categories_Registry::register was called incorrectly.
Ability category "extrachill-shop" is already registered.
in /var/www/extrachill.com/wp-includes/functions.php on line 6170
```

## Root cause

On this multisite, WordPress core's `wp_abilities_api_categories_init` action fires more than once per request. `extrachill-shop` called `wp_register_ability_category( 'extrachill-shop', ... )` unconditionally inside its hook callback with no idempotency guard, so the second fire re-registered the already-registered category and tripped `_doing_it_wrong`.

## The fix

Guard the call with core's `wp_has_ability_category()` idempotency check so a repeat fire is a clean no-op. Also keep/add the `function_exists()` guards (API may not be loaded). Slug, label, description, and hook are unchanged — only the guard was added.

```php
if ( ! function_exists( 'wp_register_ability_category' ) ) {
    return;
}
if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'extrachill-shop' ) ) {
    return;
}
wp_register_ability_category( 'extrachill-shop', array( /* unchanged */ ) );
```

One unguarded call existed in the plugin; it is now guarded. `php -l` clean.